### PR TITLE
Fix args-out-of-range error

### DIFF
--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -98,9 +98,9 @@ https://github.com/nvim-treesitter/nvim-treesitter/pull/564"
           (progn
             (insert-file-contents filename)
             (goto-char (point-min))
-            (let ((first-line-matches (save-match-data (string-match "^; *inherits *:? *\\([a-z_,()]+\\) *$" (thing-at-point 'line t))
-                                                       (match-string 1
-                                                                     (thing-at-point 'line t)))))
+            (let* ((first-line (thing-at-point 'line t))
+                   (first-line-matches (save-match-data (when (string-match "^; *inherits *:? *\\([a-z_,()]+\\) *$" first-line)
+                                                          (match-string 1 first-line)))))
               (if first-line-matches
                   (insert (string-join (mapcar (lambda (x)
                                                  (if (string-prefix-p "(" x)


### PR DESCRIPTION
Hi, thank you for this package!
I was trying to use it with python language and stumbled upon this error using `vif` 
```
evil-textobj-tree-sitter--get-query: Args out of range: "(function_definition
", 533, 534
 ```
```
Debugger entered--Lisp error: (args-out-of-range "(function_definition\n" 533 534)
  match-string(1 "(function_definition\n")
  evil-textobj-tree-sitter--get-query("python" t)
  evil-textobj-tree-sitter--get-nodes((function\.inner) 1 nil)
  evil-textobj-tree-sitter--range(1 (function\.inner) nil)
  (let ((range (evil-textobj-tree-sitter--range count '(function\.inner) nil))) (if (not (eq range nil)) (evil-range (car range) (cdr range)) (message (concat "No '" "function.inner" "' text object found"))))
  (progn (let ((range (evil-textobj-tree-sitter--range count '(function\.inner) nil))) (if (not (eq range nil)) (evil-range (car range) (cdr range)) (message (concat "No '" "function.inner" "' text object found")))))
  (setq range (progn (let ((range (evil-textobj-tree-sitter--range count '(function\.inner) nil))) (if (not (eq range nil)) (evil-range (car range) (cdr range)) (message (concat "No '" "function.inner" "' text object found"))))))
  (cond ((and (evil-visual-state-p) (called-interactively-p 'any)) (setq dir evil-visual-direction count (* count dir)) (setq range (progn (let ((range (evil-textobj-tree-sitter--range count ... nil))) (if (not (eq range nil)) (evil-range (car range) (cdr range)) (message (concat "No '" "function.inner" "' text object found")))))) (when (evil-range-p range) (setq range (evil-expand-range range)) (evil-set-type range (evil-type range type)) (setq range (evil-contract-range range)) (setq mark (evil-range-beginning range) point (evil-range-end range) type (evil-type (if evil-text-object-change-visual-type range (evil-visual-range)))) (when (and (eq type 'line) (not (eq type (evil-type range)))) (let ((newrange (evil-text-object-make-linewise range))) (setq mark (evil-range-beginning newrange) point (evil-range-end newrange)))) (when (< dir 0) (evil-swap mark point)) (evil-visual-make-selection mark point type))) (t (setq range (progn (let ((range (evil-textobj-tree-sitter--range count ... nil))) (if (not (eq range nil)) (evil-range (car range) (cdr range)) (message (concat "No '" "function.inner" "' text object found")))))) (unless (evil-range-p range) (setq count (- count) range (progn (let ((range ...)) (if (not ...) (evil-range ... ...) (message ...)))))) (when (evil-range-p range) (setq selection (evil-range (point) (point) type)) (if extend (setq range (evil-range-union range selection)) (evil-set-type range (evil-type range type))) (when (eq evil-this-type-modified 'line) (setq range (evil-text-object-make-linewise range))) (evil-set-range-properties range nil) range)))
  (let ((type (evil-type 'evil-textobj-tree-sitter-function--function\.inner evil-visual-char)) (extend (and (evil-visual-state-p) (evil-get-command-property 'evil-textobj-tree-sitter-function--function\.inner :extend-selection 't))) (dir evil-visual-direction) mark point range selection) (cond ((and (evil-visual-state-p) (called-interactively-p 'any)) (setq dir evil-visual-direction count (* count dir)) (setq range (progn (let ((range ...)) (if (not ...) (evil-range ... ...) (message ...))))) (when (evil-range-p range) (setq range (evil-expand-range range)) (evil-set-type range (evil-type range type)) (setq range (evil-contract-range range)) (setq mark (evil-range-beginning range) point (evil-range-end range) type (evil-type (if evil-text-object-change-visual-type range (evil-visual-range)))) (when (and (eq type 'line) (not (eq type ...))) (let ((newrange ...)) (setq mark (evil-range-beginning newrange) point (evil-range-end newrange)))) (when (< dir 0) (evil-swap mark point)) (evil-visual-make-selection mark point type))) (t (setq range (progn (let ((range ...)) (if (not ...) (evil-range ... ...) (message ...))))) (unless (evil-range-p range) (setq count (- count) range (progn (let (...) (if ... ... ...))))) (when (evil-range-p range) (setq selection (evil-range (point) (point) type)) (if extend (setq range (evil-range-union range selection)) (evil-set-type range (evil-type range type))) (when (eq evil-this-type-modified 'line) (setq range (evil-text-object-make-linewise range))) (evil-set-range-properties range nil) range))))
  (progn (let ((type (evil-type 'evil-textobj-tree-sitter-function--function\.inner evil-visual-char)) (extend (and (evil-visual-state-p) (evil-get-command-property 'evil-textobj-tree-sitter-function--function\.inner :extend-selection 't))) (dir evil-visual-direction) mark point range selection) (cond ((and (evil-visual-state-p) (called-interactively-p 'any)) (setq dir evil-visual-direction count (* count dir)) (setq range (progn (let (...) (if ... ... ...)))) (when (evil-range-p range) (setq range (evil-expand-range range)) (evil-set-type range (evil-type range type)) (setq range (evil-contract-range range)) (setq mark (evil-range-beginning range) point (evil-range-end range) type (evil-type (if evil-text-object-change-visual-type range ...))) (when (and (eq type ...) (not ...)) (let (...) (setq mark ... point ...))) (when (< dir 0) (evil-swap mark point)) (evil-visual-make-selection mark point type))) (t (setq range (progn (let (...) (if ... ... ...)))) (unless (evil-range-p range) (setq count (- count) range (progn (let ... ...)))) (when (evil-range-p range) (setq selection (evil-range (point) (point) type)) (if extend (setq range (evil-range-union range selection)) (evil-set-type range (evil-type range type))) (when (eq evil-this-type-modified 'line) (setq range (evil-text-object-make-linewise range))) (evil-set-range-properties range nil) range)))))
  (if (/= count 0) (progn (let ((type (evil-type 'evil-textobj-tree-sitter-function--function\.inner evil-visual-char)) (extend (and (evil-visual-state-p) (evil-get-command-property 'evil-textobj-tree-sitter-function--function\.inner :extend-selection 't))) (dir evil-visual-direction) mark point range selection) (cond ((and (evil-visual-state-p) (called-interactively-p 'any)) (setq dir evil-visual-direction count (* count dir)) (setq range (progn (let ... ...))) (when (evil-range-p range) (setq range (evil-expand-range range)) (evil-set-type range (evil-type range type)) (setq range (evil-contract-range range)) (setq mark (evil-range-beginning range) point (evil-range-end range) type (evil-type ...)) (when (and ... ...) (let ... ...)) (when (< dir 0) (evil-swap mark point)) (evil-visual-make-selection mark point type))) (t (setq range (progn (let ... ...))) (unless (evil-range-p range) (setq count (- count) range (progn ...))) (when (evil-range-p range) (setq selection (evil-range ... ... type)) (if extend (setq range ...) (evil-set-type range ...)) (when (eq evil-this-type-modified ...) (setq range ...)) (evil-set-range-properties range nil) range))))))
  (when (/= count 0) (let ((type (evil-type 'evil-textobj-tree-sitter-function--function\.inner evil-visual-char)) (extend (and (evil-visual-state-p) (evil-get-command-property 'evil-textobj-tree-sitter-function--function\.inner :extend-selection 't))) (dir evil-visual-direction) mark point range selection) (cond ((and (evil-visual-state-p) (called-interactively-p 'any)) (setq dir evil-visual-direction count (* count dir)) (setq range (progn (let (...) (if ... ... ...)))) (when (evil-range-p range) (setq range (evil-expand-range range)) (evil-set-type range (evil-type range type)) (setq range (evil-contract-range range)) (setq mark (evil-range-beginning range) point (evil-range-end range) type (evil-type (if evil-text-object-change-visual-type range ...))) (when (and (eq type ...) (not ...)) (let (...) (setq mark ... point ...))) (when (< dir 0) (evil-swap mark point)) (evil-visual-make-selection mark point type))) (t (setq range (progn (let (...) (if ... ... ...)))) (unless (evil-range-p range) (setq count (- count) range (progn (let ... ...)))) (when (evil-range-p range) (setq selection (evil-range (point) (point) type)) (if extend (setq range (evil-range-union range selection)) (evil-set-type range (evil-type range type))) (when (eq evil-this-type-modified 'line) (setq range (evil-text-object-make-linewise range))) (evil-set-range-properties range nil) range)))))
  evil-textobj-tree-sitter-function--function\.inner(nil 534 535 inclusive)
  funcall-interactively(evil-textobj-tree-sitter-function--function\.inner nil 534 535 inclusive)
```

First time it works, but the second and so forth it fails.
I guess `(thing-at-point 'line` augments `match-data` and therefore it fails second time. 

emacs 28.0.50