### PR TITLE
Fix wrong text objects in multibyte buffers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - '*'
 
 jobs:
   check:

--- a/Cask
+++ b/Cask
@@ -7,5 +7,6 @@
  (depends-on "ert")
  (depends-on "package-lint")
  (depends-on "evil")
+ (depends-on "go-mode")
  (depends-on "tree-sitter")
  (depends-on "tree-sitter-langs"))

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -4,6 +4,7 @@
 ;; We can only use statically linked files here or libstdc++ screams at you.
 ;; C is an ideal candidate for this as it is builtin and is statically linked.
 
+(require 'go-mode) ;; TODO: make this go away (find a simpler method)
 (require 'tree-sitter-langs)
 (require 'evil-textobj-tree-sitter)
 

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -50,6 +50,25 @@ int main(int temp, int temp2) {
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
+(ert-deftest evil-textobj-tree-sitter-within-unicode-test3
+    ()
+  "Simple check with point inside the calling thigy and no unicode chars"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".go"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// Комментарий
+func main(int Комментарий, int temp2) {
+    printf(\"hello\");
+}")
+      (tree-sitter-mode)
+      (goto-char 31)
+      (should (equal (evil-textobj-tree-sitter--range 1
+                                                      (list (intern "parameter.inner"))) (cons 26 41))))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
 (ert-deftest evil-textobj-tree-sitter-within-test
     ()
   "Simple check with point inside the calling thigy with unicode chars"

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -31,6 +31,25 @@ int main() {
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
+(ert-deftest evil-textobj-tree-sitter-within-unicode-test2
+    ()
+  "Simple check with point inside the calling thigy and no unicode chars"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// Комментарий
+int main(int temp, int temp2) {
+    printf(\"hello\");
+}")
+      (tree-sitter-mode)
+      (goto-char 35)
+      (should (equal (evil-textobj-tree-sitter--range 1
+                                                      (list (intern "parameter.inner"))) (cons 35 44))))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
 (ert-deftest evil-textobj-tree-sitter-within-test
     ()
   "Simple check with point inside the calling thigy with unicode chars"

--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -68,26 +68,24 @@
 
 (defun evil-textobj-tree-sitter--nodes-within (nodes)
   "NODES which contain the current point inside them ordered inside out."
-  (let ((byte-pos (position-bytes (point))))
-    (sort (cl-remove-if-not (lambda (x)
-                              (and (<= (car (tsc-node-byte-range x)) byte-pos)
-                                   (< byte-pos (cdr (tsc-node-byte-range x)))))
-                            nodes)
-          (lambda (x y)
-            (< (+ (abs (- byte-pos
-                          (car (tsc-node-byte-range x))))
-                  (abs (- byte-pos
-                          (cdr (tsc-node-byte-range x))))) (+ (abs (- byte-pos
-                          (car (tsc-node-byte-range y))))
-                  (abs (- byte-pos
-                          (cdr (tsc-node-byte-range y))))))))))
+  (sort (cl-remove-if-not (lambda (x)
+                            (and (<= (byte-to-position (car (tsc-node-byte-range x))) (point))
+                                 (< (point) (byte-to-position (cdr (tsc-node-byte-range x))))))
+                          nodes)
+        (lambda (x y)
+          (< (+ (abs (- (point)
+                        (car (tsc-node-byte-range x))))
+                (abs (- (point)
+                        (cdr (tsc-node-byte-range x))))) (+ (abs (- (point)
+                        (car (tsc-node-byte-range y))))
+                (abs (- (point)
+                        (cdr (tsc-node-byte-range y)))))))))
 
 (defun evil-textobj-tree-sitter--nodes-after (nodes)
   "NODES which contain the current point before them ordered top to bottom."
-  (let ((byte-pos (position-bytes (point))))
-    (cl-remove-if-not (lambda (x)
-                        (> (car (tsc-node-byte-range x)) byte-pos))
-                      nodes)))
+  (cl-remove-if-not (lambda (x)
+                      (> (byte-to-position (car (tsc-node-byte-range x))) (point)))
+                    nodes))
 
 (defun evil-textobj-tree-sitter--get-query (language top-level)
   "Get tree sitter query for LANGUAGE.
@@ -101,7 +99,8 @@ https://github.com/nvim-treesitter/nvim-treesitter/pull/564"
             (insert-file-contents filename)
             (goto-char (point-min))
             (let* ((first-line (thing-at-point 'line t))
-                   (first-line-matches (save-match-data (when (string-match "^; *inherits *:? *\\([a-z_,()]+\\) *$" first-line)
+                   (first-line-matches (save-match-data (when (string-match "^; *inherits *:? *\\([a-z_,()]+\\) *$"
+                                                                            first-line)
                                                           (match-string 1 first-line)))))
               (if first-line-matches
                   (insert (string-join (mapcar (lambda (x)

--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -68,24 +68,26 @@
 
 (defun evil-textobj-tree-sitter--nodes-within (nodes)
   "NODES which contain the current point inside them ordered inside out."
-  (sort (cl-remove-if-not (lambda (x)
-                            (and (<= (car (tsc-node-byte-range x)) (point))
-                                 (< (point) (cdr (tsc-node-byte-range x)))))
-                          nodes)
-        (lambda (x y)
-          (< (+ (abs (- (point)
-                        (car (tsc-node-byte-range x))))
-                (abs (- (point)
-                        (cdr (tsc-node-byte-range x))))) (+ (abs (- (point)
-                        (car (tsc-node-byte-range y))))
-                (abs (- (point)
-                        (cdr (tsc-node-byte-range y)))))))))
+  (let ((byte-pos (position-bytes (point))))
+    (sort (cl-remove-if-not (lambda (x)
+                              (and (<= (car (tsc-node-byte-range x)) byte-pos)
+                                   (< byte-pos (cdr (tsc-node-byte-range x)))))
+                            nodes)
+          (lambda (x y)
+            (< (+ (abs (- byte-pos
+                          (car (tsc-node-byte-range x))))
+                  (abs (- byte-pos
+                          (cdr (tsc-node-byte-range x))))) (+ (abs (- byte-pos
+                          (car (tsc-node-byte-range y))))
+                  (abs (- byte-pos
+                          (cdr (tsc-node-byte-range y))))))))))
 
 (defun evil-textobj-tree-sitter--nodes-after (nodes)
   "NODES which contain the current point before them ordered top to bottom."
-  (cl-remove-if-not (lambda (x)
-                      (> (car (tsc-node-byte-range x)) (point)))
-                    nodes))
+  (let ((byte-pos (position-bytes (point))))
+    (cl-remove-if-not (lambda (x)
+                        (> (car (tsc-node-byte-range x)) byte-pos))
+                      nodes)))
 
 (defun evil-textobj-tree-sitter--get-query (language top-level)
   "Get tree sitter query for LANGUAGE.


### PR DESCRIPTION
Hi,
For example, consider the following buffer:

```c
// Комментарий
int main(int temp, |int temp2) {
    printf("hello");
}
```
with point on the second parameter of the function.
If you try to select `@parameter.inner` then the first parameter will be selected.

```c
// Комментарий
int main([int temp], int temp2) {
    printf("hello");
}
```
I've added test case for this fix.