### PR TITLE
Goto

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,41 @@ to work for*
                                                 (rust-mode . [(use_declaration) @import]))))
 ```
 
+# Goto
+
+We have also added support for for a fancier version of
+`goto-char`. You can use this to go to the next function, previous
+class or do any motions like that.
+
+You can use the `evil-textobj-tree-sitter-goto-textobj` function to
+invoke goto. You can either use this in other function or just bound
+to a key. The first argument is the textobj that you want to use, the
+second one specifies if you want to search forward or backward and the
+last one is for specifying wheather to go to the start or end of the
+textobj.
+
+Below are some sample binding that you can do. You can use any textobj
+that is available here.
+
+``` emacs-lisp
+;; Goto start of next function
+(define-key evil-normal-state-map (kbd "]f") (lambda ()
+                                                  (interactive)
+                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer")))
+;; Goto start of previous function
+(define-key evil-normal-state-map (kbd "[f") (lambda ()
+                                                  (interactive)
+                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" t)))
+;; Goto end of next function
+(define-key evil-normal-state-map (kbd "]F") (lambda ()
+                                                  (interactive)
+                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" nil t)))
+;; Goto end of previous function
+(define-key evil-normal-state-map (kbd "[F") (lambda ()
+                                                  (interactive)
+                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" t t)))
+```
+
 # Contributing new textobjects
 
 As I have already mentioned, I pull the text objects from

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -398,6 +398,7 @@ int main3() {
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
+      (setq major-mode 'go-mode)
       (insert "// comment
 func main() {
 	fmt.Println(\"howdy bruh!\")
@@ -411,7 +412,7 @@ func main() {
                                                                           (list "function.outer"))
                                                                   t
                                                                   nil
-                                                                  nil) 56)))
+                                                                  nil) 55)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -195,4 +195,224 @@ int main() {
                              (evil-textobj-tree-sitter--get-query "typescript"
                                                                   nil)))))
 
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-start-simple
+    ()
+  "Go to next start simple test"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}")
+      (tree-sitter-mode)
+      (goto-char 1)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  nil
+                                                                  nil
+                                                                  nil) 10)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-start-unicode
+    ()
+  "Go to next start with unicode in comment"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// Łukasz
+int main() {
+    printf(\"hello\")
+}")
+      (tree-sitter-mode)
+      (goto-char 1)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  nil
+                                                                  nil
+                                                                  nil) 11)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-end-simple
+    ()
+  "Go to next start simple test"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+")
+      (tree-sitter-mode)
+      (goto-char 1)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  nil
+                                                                  t
+                                                                  nil) 44)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-end-multi
+    ()
+  "Go to next start simple test"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+")
+      (tree-sitter-mode)
+      (goto-char 46)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  nil
+                                                                  t
+                                                                  nil) 82)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi
+    ()
+  "Go to next start simple test"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+
+int main3() {
+    printf(\"hello3\")
+}
+")
+      (tree-sitter-mode)
+      (goto-char 83)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  t
+                                                                  t
+                                                                  nil) 82)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end
+    ()
+  "Testing going to end of previous one while on end of current one."
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+
+int main3() {
+    printf(\"hello3\")
+}
+")
+      (tree-sitter-mode)
+      (goto-char 82)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  t
+                                                                  t
+                                                                  nil) 44)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-start-multi-on-start
+    ()
+  "Testing going to start of previous one while on start of current one."
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+
+int main3() {
+    printf(\"hello3\")
+}
+")
+      (tree-sitter-mode)
+      (goto-char 46)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  t
+                                                                  nil
+                                                                  nil) 10)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested
+    ()
+  "Go to next start simple test"
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".go"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// comment
+func main() {
+	fmt.Println(\"howdy bruh!\")
+	func() {
+		fmt.Println(\"yo!\")
+	}
+}")
+      (tree-sitter-mode)
+      (goto-char 66)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  t
+                                                                  nil
+                                                                  nil) 56)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
 ;;; evil-textobj-tree-sitter-test.el ends here

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -20,14 +20,14 @@
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
-      (insert "# Łukasz
+      (insert "// Łukasz
 int main() {
     printf(\"hello\")
 }")
       (tree-sitter-mode)
       (goto-char 31)
       (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 21 44))))
+                                                      (list (intern "function.inner"))) (cons 22 45))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -97,14 +97,14 @@ int main() {
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
-      (insert "# Lukasz
+      (insert "// Lukasz
 int main() {
     printf(\"hello\")
 }")
       (tree-sitter-mode)
       (goto-char 31)
       (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 21 44))))
+                                                      (list (intern "function.inner"))) (cons 22 45))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -117,14 +117,14 @@ int main() {
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
-      (insert "# Lukasz
+      (insert "// Lukasz
 int main() {
     printf(\"hello\")
 }")
       (tree-sitter-mode)
       (goto-char 1)
       (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 21 44))))
+                                                      (list (intern "function.inner"))) (cons 22 45))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -136,14 +136,14 @@ int main() {
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
-      (insert "# Lukasz
+      (insert "// Lukasz
 int main() {
     printf(\"hello\")
 }")
       (tree-sitter-mode)
       (goto-char 10)
       (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 21 44))))
+                                                      (list (intern "function.inner"))) (cons 22 45))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -263,7 +263,7 @@ int main2() {
                                                                           (list "function.outer"))
                                                                   nil
                                                                   t
-                                                                  nil) 44)))
+                                                                  nil) 43)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -291,7 +291,7 @@ int main2() {
                                                                           (list "function.outer"))
                                                                   nil
                                                                   t
-                                                                  nil) 82)))
+                                                                  nil) 81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -322,7 +322,7 @@ int main3() {
                                                                           (list "function.outer"))
                                                                   t
                                                                   t
-                                                                  nil) 82)))
+                                                                  nil) 81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -353,7 +353,72 @@ int main3() {
                                                                           (list "function.outer"))
                                                                   t
                                                                   t
-                                                                  nil) 44)))
+                                                                  nil) 43)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end-with-comment-at-end
+    ()
+  "Testing going to end of previous one while on end of current one."
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+} // one
+
+int main2() {
+    printf(\"hello2\")
+} // two
+
+int main3() {
+    printf(\"hello3\")
+} // three
+")
+      (tree-sitter-mode)
+      (goto-char 82)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  t
+                                                                  t
+                                                                  nil) 43)))
+    (set-buffer-modified-p nil)
+    (kill-buffer bufname)))
+
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-end-multi-on-end
+    ()
+  "Testing going to end of previous one while on end of current one."
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
+                          ".c"))
+         (filename (concat "/tmp/" bufname)))
+    (find-file filename)
+    (with-current-buffer bufname
+      (insert "// mango
+int main() {
+    printf(\"hello\")
+}
+
+int main2() {
+    printf(\"hello2\")
+}
+
+int main3() {
+    printf(\"hello3\")
+}
+")
+      (tree-sitter-mode)
+      ;; somehow (goto-char 44) (point) gives 43?
+      (goto-char 43)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
+                                                                          (list "function.outer"))
+                                                                  nil
+                                                                  t
+                                                                  nil) 81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 

--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -66,6 +66,12 @@
   (setf (map-elt evil-textobj-tree-sitter-major-mode-language-alist
                  major-mode) lang-symbol))
 
+(defun evil-textobj-tree-sitter--nodes-before (nodes)
+  "NODES which contain the current after them."
+  (cl-remove-if-not (lambda (x)
+                      (< (byte-to-position (cdr (tsc-node-byte-range x))) (point)))
+                    nodes))
+
 (defun evil-textobj-tree-sitter--nodes-within (nodes)
   "NODES which contain the current point inside them ordered inside out."
   (let ((byte-pos (position-bytes (point))))
@@ -114,12 +120,11 @@ https://github.com/nvim-treesitter/nvim-treesitter/pull/564"
                                        "\n"))))
             (buffer-string))))))
 
-(defun evil-textobj-tree-sitter--get-nodes (group count &optional query)
+(defun evil-textobj-tree-sitter--get-nodes (group query)
   "Get a list of viable nodes based on `GROUP' value.
 They will be order with captures with point inside them first then the
-ones that follow.  This will return n(`COUNT') items.  If a `QUERY'
-alist is provided, we make use of that instead of the builtin query
-set."
+ones that follow.  If a `QUERY' alist is provided, we make use of that
+instead of the builtin query set."
   (let* ((lang-name (alist-get major-mode evil-textobj-tree-sitter-major-mode-language-alist))
          (debugging-query (if (eq query nil)
                               (evil-textobj-tree-sitter--get-query lang-name
@@ -131,16 +136,21 @@ set."
          (filtered-captures (cl-remove-if-not (lambda (x)
                                                 (member (car x) group))
                                               captures))
-         (nodes (seq-map #'cdr filtered-captures))
-         (nodes-nodupes (cl-remove-duplicates nodes
-                                              :test (lambda (x y)
-                                                      (and (= (car (tsc-node-byte-range x)) (car (tsc-node-byte-range y)))
-                                                           (= (cdr (tsc-node-byte-range x)) (cdr (tsc-node-byte-range y)))))))
-         (nodes-within (evil-textobj-tree-sitter--nodes-within nodes-nodupes))
-         (nodes-after (evil-textobj-tree-sitter--nodes-after nodes-nodupes))
-         (all-nodes (append nodes-within nodes-after)))
-    (if (> (length all-nodes) 0)
-        (cl-subseq all-nodes 0 count))))
+         (nodes (seq-map #'cdr filtered-captures)))
+    (cl-remove-duplicates nodes
+                          :test (lambda (x y)
+                                  (and (= (car (tsc-node-byte-range x)) (car (tsc-node-byte-range y)))
+                                       (= (cdr (tsc-node-byte-range x)) (cdr (tsc-node-byte-range y))))))))
+
+(defun evil-textobj-tree-sitter--get-within-and-after (group count query)
+  "Given a `GROUP' `QUERY' find `COUNT' number of nodes within in and after current point."
+  (let* ((nodes (evil-textobj-tree-sitter--get-nodes group
+                                                     query))
+         (nodes-within (evil-textobj-tree-sitter--nodes-within nodes))
+         (nodes-after (evil-textobj-tree-sitter--nodes-after nodes))
+         (filtered-nodes (append nodes-within nodes-after)))
+    (if (> (length filtered-nodes) 0)
+        (cl-subseq filtered-nodes 0 count))))
 
 (defun evil-textobj-tree-sitter--range (count ts-group &optional query)
   "Get the range of the closeset item of type `TS-GROUP'.
@@ -151,8 +161,8 @@ are doing.  If a `QUERY' alist is provided, we make use of that
 instead of the builtin query set."
   (if (equal tree-sitter-mode nil)
       (message "tree-sitter-mode not enabled for buffer")
-    (let ((nodes (evil-textobj-tree-sitter--get-nodes ts-group
-                                                      count query)))
+    (let ((nodes (evil-textobj-tree-sitter--get-within-and-after
+                  ts-group count query)))
       (if (not (eq nodes nil))
           (let ((range-min (apply #'min
                                   (seq-map (lambda (x)
@@ -194,6 +204,49 @@ https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobje
              (evil-range (car range)
                          (cdr range))
            (message (concat "No '" ,group "' text object found")))))))
+
+(defun evil-textobj-tree-sitter--get-goto-location (groups previous end query)
+  "Get the start/end of the textobj of type `GROUPS'.
+By default it goes to the start of the textobj, but pass in `END' if
+you want to go to the end of the textobj instead.  You can pass in
+`PREVIOUS' if you want to search backwards.  `QUERY' for custom queries."
+  (let* ((nodes (evil-textobj-tree-sitter--get-nodes groups
+                                                     query))
+         (nodes-before (reverse (evil-textobj-tree-sitter--nodes-before nodes)))
+         (nodes-within (evil-textobj-tree-sitter--nodes-within nodes))
+         (nodes-after (evil-textobj-tree-sitter--nodes-after nodes))
+         (node (car (if previous
+                        (if end
+                            nodes-before
+                          (cl-remove-if (lambda (x)
+                                          "Remove the item if we already on the start of that one."
+                                          (= (byte-to-position (car (tsc-node-byte-range x))) (point)))
+                                        (append nodes-within nodes-before)))
+                      (if end
+                          (append nodes-within nodes-after)
+                        nodes-after)))))
+    (if node
+        (cl-callf byte-to-position
+            (if end
+                (cdr (tsc-node-byte-range node))
+              (car (tsc-node-byte-range node)))))))
+
+;;;###autoload
+(defun evil-textobj-tree-sitter-goto-textobj (group &optional previous end query)
+  "Got to the start/end of the textobj of type `GROUP'.
+By default it goes to the start of the textobj, but pass in `END' if
+you want to go to the end of the textobj instead.  You can pass in
+`PREVIOUS' if you want to search backwards.  Optionally pass in
+`QUERY' if you want to define a custom query."
+  (let* ((groups (if (eq (type-of group) 'string)
+                     (list group)
+                   group))
+         (interned-groups (mapcar #'intern groups))
+         (goto-position (evil-textobj-tree-sitter--get-goto-location
+                         interned-groups previous end query)))
+    (if goto-position
+        (goto-char goto-position)
+      (message (concat "No '" interned-groups "' text object found")))))
 
 (provide 'evil-textobj-tree-sitter)
 ;;; evil-textobj-tree-sitter.el ends here


### PR DESCRIPTION
You can use the `evil-textobj-tree-sitter-goto-textobj` function to invoke goto. You can either use this in other function or just bound to a key. The first argument is the textobj that you want to use, the second one specifies if you want to search forward or backward and the last one is for specifying wheather to go to the start or end of the textobj.

Below are some sample binding that you can do. You can use any textobj that is available here.

``` emacs-lisp
;; Goto start of next function
(define-key evil-normal-state-map (kbd "]f") (lambda ()
                                                  (interactive)
                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer")))
;; Goto start of previous function
(define-key evil-normal-state-map (kbd "[f") (lambda ()
                                                  (interactive)
                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" t)))
;; Goto end of next function
(define-key evil-normal-state-map (kbd "]F") (lambda ()
                                                  (interactive)
                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" nil t)))
;; Goto end of previous function
(define-key evil-normal-state-map (kbd "[F") (lambda ()
                                                  (interactive)
                                                  (evil-textobj-tree-sitter-goto-textobj "function.outer" t t)))
```
