### PR TITLE
Prevent byte compiler warning

### DIFF
--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -187,7 +187,8 @@ https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobje
                                     (mapconcat 'identity groups "-"))))
          (interned-groups (mapcar #'intern groups)))
     `(evil-define-text-object ,funsymbol
-       (count &rest _)
+       ;; rest argument is named because of compiler warning `argument _ not left unused`
+       (count &rest unused)
        (let ((range (evil-textobj-tree-sitter--range count ',interned-groups
                                                      ,query)))
          (if (not (eq range nil))


### PR DESCRIPTION
Warning: argument ‘_’ not left unused is emitted when `_` is used as the rest argument name.

See here for precedent: https://github.com/porras/evil-ruby-text-objects/blob/32983d91be83ed903b6ef9655e00f69beed2572c/evil-ruby-text-objects.el#L156-L157