### PR TITLE
Update major-mode mapping (add haskell)

### DIFF
--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -49,6 +49,7 @@
                           (elixir-mode . "elixir")
                           (elm-mode . "elm")
                           (go-mode . "go")
+                          (haskell-mode . "haskell")
                           (html-mode . "html")
                           (java-mode . "java")
                           (javascript-mode . "javascript")


### PR DESCRIPTION
textobjects for haskell has been merged in #48