### PR TITLE
Add support for builtin treesit using helix queries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 27.2
-          - 28.1
+          # - 27.2
+          # - 28.1
+          - snapshot # test only on snapshot as that has treesit
     steps:
     - uses: actions/checkout@v2
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   check:

--- a/Cask
+++ b/Cask
@@ -9,4 +9,5 @@
  (depends-on "evil")
  (depends-on "tree-sitter")
  (depends-on "go-mode")
- (depends-on "tree-sitter-langs"))
+ (depends-on "tree-sitter-langs")
+ (depends-on "treesit-auto"))

--- a/Cask
+++ b/Cask
@@ -8,4 +8,5 @@
  (depends-on "package-lint")
  (depends-on "evil")
  (depends-on "tree-sitter")
+ (depends-on "go-mode")
  (depends-on "tree-sitter-langs"))

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ grammars. You can easily create function,class,comment etc textobjects
 in multiple languages. It also make additional `things` available in
 `thing-at-point` like `function`, `class`, `loop`, `comment` etc.
 
+> It can work with either elisp-tree-sitter or the builtin treesit library.
+
 # Installation
 
 You can install `evil-textobj-tree-sitter` from melpa. Here is how you would do it using `use-package` and `package.el`:
@@ -67,15 +69,6 @@ should be relatively easy to add them.
 (define-key evil-outer-text-objects-map "a" (evil-textobj-tree-sitter-get-textobj ("conditional.outer" "loop.outer")))
 ```
 
-We support quite a few textobjects. You can find a list of available
-textobjects at
-[nvim-treesitter/nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects).
-We might not have support for all of them as
-[emacs-tree-sitter](https://github.com/ubolonton/emacs-tree-sitter)
-does not yet support all the languages as of now. As for the list of
-languages that we support you can check the value of
-`evil-textobj-tree-sitter-major-mode-language-alist`.
-
 ## Custom textobjects
 
 If you are not able to find the text object that you are looking for
@@ -130,22 +123,29 @@ that is available here.
                                                   (evil-textobj-tree-sitter-goto-textobj "function.outer" t t)))
 ```
 
-# Contributing new textobjects
+# Finding and contributing to textobjects
 
-As I have already mentioned, I pull the text objects from
+`evil-textobj-tree-sitter` work with both builtin `treesit` and
+`elisp-tree-sitter`. The queries in use are a bit different in both
+cases with the `elisp-tree-sitter` version currently being more feature
+complete. In both cases we pull the queries from external sources. For
+`elisp-tree-sitter`, we source them from
 [nvim-treesitter/nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects#built-in-textobjects)
-project. This right now automatically happens every friday using a
-[Github Action](https://github.com/meain/evil-textobj-tree-sitter/blob/master/.github/workflows/update-queries.yaml)
-which will create a new PR on the repo. So if you would like to
-update/add the builtin tree-sitter objects, feel free to update them
-in the neovim project repository. Unless there is something Emacs
-specific I recommend everyone to just submit the new queries to that
-project.
+and is places into
+[queries](https://github.com/meain/evil-textobj-tree-sitter/tree/master/queries)
+directory. And for `treesit` queries, it is sourced from
+[helix](https://github.com/helix-editor/helix/tree/master/runtime/queries)
+and placed in
+[treesit-queries](https://github.com/meain/evil-textobj-tree-sitter/tree/master/treesit-queries).
+You can check these files to see what all is available. If you are
+interesting in contributing additional textobjects, you can do so by
+submitting to the respective projects. If there is enough interest, I
+don't mind starting to manage queries ourselves.
 
 If you are adding a completely new language, there is two other things
 that you will have to do to make sure everything will work well.
 
-1. Make sure the lang is available in [emacs-tree-sitter/tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs/tree/master/queries)
+1. Make sure the lang is available in [emacs-tree-sitter/tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs/tree/master/queries) or `treesit`.
 2. Make sure we have a `major-mode` mapping in [evil-textobj-tree-sitter-major-mode-language-alist](https://github.com/meain/evil-textobj-tree-sitter/blob/d416b3ab8610f179defadd58f5c20fdc65bf21e5/evil-textobj-tree-sitter.el#L40)
 
 *If you would like to test out new textobjects, I would suggest using

--- a/evil-textobj-tree-sitter-core.el
+++ b/evil-textobj-tree-sitter-core.el
@@ -3,7 +3,7 @@
 ;; URL: https://github.com/meain/evil-textobj-tree-sitter
 ;; Keywords: evil, tree-sitter, text-object, convenience
 ;; SPDX-License-Identifier: Apache-2.0
-;; Package-Requires: ((emacs "25.1") (tree-sitter "0.15.0"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 0.1
 
 ;;; Commentary:

--- a/evil-textobj-tree-sitter-query-test.el
+++ b/evil-textobj-tree-sitter-query-test.el
@@ -2,6 +2,7 @@
 
 (require 'tree-sitter-langs)
 (require 'evil-textobj-tree-sitter)
+(require 'ert)
 
 (defun evil-textobj-tree-sitter--test-loading-with-comment-prefix (lang comment-prefix)
   "Try loading grammar for `LANG' and test with comment using `COMMENT-PREFIX'."
@@ -10,7 +11,8 @@
    (concat comment-prefix " howdy!")))
 
 (defun evil-textobj-tree-sitter--test-loading-with-comment (lang text &optional region)
-  "Try loading grammar for `LANG' and test with comment provided in `TEXT' optionally passing in `REGION'."
+  "Try loading grammar for `LANG'.
+And test with comment provided in `TEXT' optionally passing in `REGION'."
   (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
          (filename (concat "/tmp/" bufname)))
 

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -11,8 +11,7 @@
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -22,15 +21,15 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 31)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 28 43))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
+               (cons 28 43))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test-outer ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -40,15 +39,15 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 31)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.outer"))) (cons 11 45))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "function.outer")))
+               (cons 11 45))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test2 ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -58,15 +57,15 @@ int main(int temp, int temp2) {
 }")
       (tree-sitter-mode)
       (goto-char 35)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "parameter.inner"))) (cons 35 44))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "parameter.inner")))
+               (cons 35 44))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test3 ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".go"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".go"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -77,15 +76,15 @@ func main(int Комментарий, int temp2) {
 }")
       (tree-sitter-mode)
       (goto-char 31)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "parameter.inner"))) (cons 26 41))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "parameter.inner")))
+               (cons 26 41))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test4 ()
   "Check sorting of nested object in multibyte file."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -95,15 +94,15 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 100)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "conditional.outer"))) (cons 88 104))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "conditional.outer")))
+               (cons 88 104))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-within-test ()
   "Simple check with point inside the calling thigy with unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -113,16 +112,16 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 31)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 28 43))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
+               (cons 28 43))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-lookahed-test ()
   "Check with lookahed."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -132,15 +131,15 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 28 43))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
+               (cons 28 43))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-right-at-start-test ()
   "Checking for off by one errors at start."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -150,8 +149,9 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 10)
-      (should (equal (evil-textobj-tree-sitter--range 1
-                                                      (list (intern "function.inner"))) (cons 28 43))))
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
+               (cons 28 43))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
@@ -159,49 +159,41 @@ int main() {
   "Simple query read check."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p ";; \"Classes\""
-                             (evil-textobj-tree-sitter--get-query "zig"
-                                                                  t)))))
+                             (evil-textobj-tree-sitter--get-query "zig" t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nocomment ()
   "Check a query file with no comment."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "(function_definition"
-                             (evil-textobj-tree-sitter--get-query "bash"
-                                                                  t)))))
+                             (evil-textobj-tree-sitter--get-query "bash" t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested ()
   "Check a query with nested files to be loaded."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (jsx)"
-                             (evil-textobj-tree-sitter--get-query "typescript"
-                                                                  t)))))
+                             (evil-textobj-tree-sitter--get-query "typescript" t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested-nofile ()
   "Check a file pointing to a non existent file."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (jsx)"
-                             (evil-textobj-tree-sitter--get-query "javascript"
-                                                                  t)))))
+                             (evil-textobj-tree-sitter--get-query "javascript" t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested-multi ()
   "Check a query with multiple nesting items."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (javascript)"
-                             (evil-textobj-tree-sitter--get-query "tsx"
-                                                                  t)))))
+                             (evil-textobj-tree-sitter--get-query "tsx" t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-non-top-level ()
   "Check a non top level direct query."
   (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (javascript)"
-                             (evil-textobj-tree-sitter--get-query "typescript"
-                                                                  nil)))))
-
+                             (evil-textobj-tree-sitter--get-query "typescript" nil)))))
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-start-simple ()
   "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -211,18 +203,16 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  nil
-                                                                  nil
-                                                                  nil) 10)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      nil nil nil)
+                     10)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-start-simple2 ()
   "Go to next start simple test.  This is to check if sorting is working."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -232,18 +222,16 @@ func main(arg1, arg2) {
 }")
       (tree-sitter-mode)
       (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "parameter.outer"))
-                                                                  nil
-                                                                  nil
-                                                                  nil) 20)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "parameter.outer"))
+                      nil nil nil)
+                     20)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-start-unicode ()
   "Go to next start with unicode in comment."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -253,18 +241,16 @@ int main() {
 }")
       (tree-sitter-mode)
       (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  nil
-                                                                  nil
-                                                                  nil) 11)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      nil nil nil)
+                     11)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-end-simple ()
   "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -279,19 +265,17 @@ int main2() {
 ")
       (tree-sitter-mode)
       (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  nil
-                                                                  t
-                                                                  nil) 43)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      nil t nil)
+                     43)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-end-multi ()
   "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -306,18 +290,16 @@ int main2() {
 ")
       (tree-sitter-mode)
       (goto-char 46)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  nil
-                                                                  t
-                                                                  nil) 81)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      nil t nil)
+                     81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi ()
   "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -336,18 +318,16 @@ int main3() {
 ")
       (tree-sitter-mode)
       (goto-char 83)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  t
-                                                                  t
-                                                                  nil) 81)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      t t nil)
+                     81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end ()
   "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -366,19 +346,17 @@ int main3() {
 ")
       (tree-sitter-mode)
       (goto-char 82)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  t
-                                                                  t
-                                                                  nil) 43)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      t t nil)
+                     43)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end-with-comment-at-end ()
   "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -397,19 +375,17 @@ int main3() {
 ")
       (tree-sitter-mode)
       (goto-char 82)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  t
-                                                                  t
-                                                                  nil) 43)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      t t nil)
+                     43)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-end-multi-on-end ()
   "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -429,19 +405,17 @@ int main3() {
       (tree-sitter-mode)
       ;; somehow (goto-char 44) (point) gives 43?
       (goto-char 43)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  nil
-                                                                  t
-                                                                  nil) 81)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      nil t nil)
+                     81)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-start-multi-on-start ()
   "Testing going to start of previous one while on start of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -460,19 +434,17 @@ int main3() {
 ")
       (tree-sitter-mode)
       (goto-char 46)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  t
-                                                                  nil
-                                                                  nil) 10)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      t nil nil)
+                     10)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested ()
   "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".go"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".go"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -486,18 +458,16 @@ func main() {
 }")
       (tree-sitter-mode)
       (goto-char 66)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location (mapcar #'intern
-                                                                          (list "function.outer"))
-                                                                  t
-                                                                  nil
-                                                                  nil) 55)))
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (mapcar #'intern (list "function.outer"))
+                      t nil nil)
+                     55)))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested-2 ()
   "Go to previous nested function test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".py"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
          (filename (concat "/tmp/" bufname)))
     (setq python-indent-guess-indent-offset nil
           python-indent-offset 4)
@@ -522,8 +492,7 @@ func main() {
 
 (ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested-3 ()
   "Go to previous nested complex test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".py"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
          (filename (concat "/tmp/" bufname)))
     (setq python-indent-guess-indent-offset nil
           python-indent-offset 4)
@@ -552,8 +521,7 @@ func main() {
 
 (ert-deftest evil-textobj-tree-sitter-goto-next-end-nested-2 ()
   "Go to next nested function test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".py"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
          (filename (concat "/tmp/" bufname)))
     (setq python-indent-guess-indent-offset nil
           python-indent-offset 4)
@@ -572,7 +540,7 @@ func main() {
       (goto-char 18)
       (let ((pos (evil-textobj-tree-sitter--get-goto-location
                   (mapcar #'intern (list "function.outer")) nil t nil)))
-      ;; cursor should be on the end of nested function (var2)
+        ;; cursor should be on the end of nested function (var2)
         (should (equal pos 52))))
     (set-buffer-modified-p nil)
     (kill-buffer bufname)))
@@ -580,8 +548,7 @@ func main() {
 ;;; `thing-at-point' tests
 (ert-deftest evil-textobj-tree-sitter-thing-at-point ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname
@@ -599,8 +566,7 @@ int main() {
 
 (ert-deftest evil-textobj-tree-sitter-thing-at-point-bounds ()
   "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--")
-                          ".c"))
+  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
          (filename (concat "/tmp/" bufname)))
     (find-file filename)
     (with-current-buffer bufname

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -8,6 +8,20 @@
 
 (require 'tree-sitter-langs)
 (require 'evil-textobj-tree-sitter)
+(require 'go-mode)
+
+(setq treesit-language-source-alist
+      '((c . ("https://github.com/tree-sitter/tree-sitter-c"))
+        (cpp . ("https://github.com/tree-sitter/tree-sitter-cpp"))
+        (python . ("https://github.com/tree-sitter/tree-sitter-python"))
+        (go . ("https://github.com/tree-sitter/tree-sitter-go"))
+        (gomod . ("https://github.com/camdencheek/tree-sitter-go-mod.git"))))
+
+(treesit-install-language-grammar 'c)
+(treesit-install-language-grammar 'cpp)
+(treesit-install-language-grammar 'python)
+(treesit-install-language-grammar 'go)
+(treesit-install-language-grammar 'gomod)
 
 (defun evil-textobj-tree-sitter--range-test (mode treesit start textobj range content)
   "Check ranges of tree-sitter targets.
@@ -24,6 +38,7 @@
       (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
       (funcall mode)
       (if (not treesit) (tree-sitter-mode))
+      (message "%s" major-mode)
       (goto-char start)
       (should (equal
                (evil-textobj-tree-sitter--range 1 (list (intern textobj)))

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -9,497 +9,61 @@
 (require 'tree-sitter-langs)
 (require 'evil-textobj-tree-sitter)
 
-(ert-deftest evil-textobj-tree-sitter-within-unicode-test ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Łukasz
+(defun evil-textobj-tree-sitter--range-test (mode treesit start textobj range content)
+  "Check ranges of tree-sitter targets.
+
+`MODE' is the `major-mode' to be used.
+`TREESIT' non nil will use `treesit'.
+`CONTENT' is the content to be used.
+`START' is the starting position.
+`TEXTOBJ' is the textobject to check.
+`RANGE' is the range that should be returned."
+  (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
+         (buffer (get-buffer-create bufname)))
+    (with-current-buffer buffer
+      (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
+      (funcall mode)
+      (if (not treesit) (tree-sitter-mode))
+      (goto-char start)
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern textobj)))
+               range)))
+    (kill-buffer buffer)))
+
+(defvar evil-textobj-tree-sitter--test-file-content
+  '((c-simple . "// Lukasz
 int main() {
     printf(\"hello\")
 }")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
-               (cons 28 43))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
+    (c-multiple-funcs .  "// mango
+int main() {
+    printf(\"hello\")
+}
 
-(ert-deftest evil-textobj-tree-sitter-within-unicode-test-outer ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Łukasz
+int main2() {
+    printf(\"hello2\")
+}
+")
+    (c-unicode . "// Łukasz
 int main() {
     printf(\"hello\")
 }")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "function.outer")))
-               (cons 11 45))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-within-unicode-test2 ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Комментарий
+    (c-multibyte . "// Комментарий
 int main(int temp, int temp2) {
     printf(\"hello\");
 }")
-      (tree-sitter-mode)
-      (goto-char 35)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "parameter.inner")))
-               (cons 35 44))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-within-unicode-test3 ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".go"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (setq major-mode 'go-mode)
-      (insert "// Комментарий
+    (go-multibyte-code . "// Комментарий
 func main(int Комментарий, int temp2) {
     printf(\"hello\");
 }")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "parameter.inner")))
-               (cons 26 41))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-within-unicode-test4 ()
-  "Check sorting of nested object in multibyte file."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Комментарий Комментарий Комментарий Комментарий Комментарий
-int main() {
-    if (1) if (0) { true; }
-}")
-      (tree-sitter-mode)
-      (goto-char 100)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "conditional.outer")))
-               (cons 88 104))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-within-test ()
-  "Simple check with point inside the calling thigy with unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Lukasz
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
-               (cons 28 43))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-lookahed-test ()
-  "Check with lookahed."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Lukasz
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 1)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
-               (cons 28 43))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-right-at-start-test ()
-  "Checking for off by one errors at start."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Lukasz
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 10)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern "function.inner")))
-               (cons 28 43))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-simple ()
-  "Simple query read check."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p ";; \"Classes\""
-                             (evil-textobj-tree-sitter--get-query "zig" t)))))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-nocomment ()
-  "Check a query file with no comment."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p "(function_definition"
-                             (evil-textobj-tree-sitter--get-query "bash" t)))))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-nested ()
-  "Check a query with nested files to be loaded."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p "; inherits: (jsx)"
-                             (evil-textobj-tree-sitter--get-query "typescript" t)))))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-nested-nofile ()
-  "Check a file pointing to a non existent file."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p "; inherits: (jsx)"
-                             (evil-textobj-tree-sitter--get-query "javascript" t)))))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-nested-multi ()
-  "Check a query with multiple nesting items."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p "; inherits: (javascript)"
-                             (evil-textobj-tree-sitter--get-query "tsx" t)))))
-
-(ert-deftest evil-textoj-tree-sitter-check-query-read-non-top-level ()
-  "Check a non top level direct query."
-  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
-    (should (string-prefix-p "; inherits: (javascript)"
-                             (evil-textobj-tree-sitter--get-query "typescript" nil)))))
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-start-simple ()
-  "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      nil nil nil)
-                     10)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-start-simple2 ()
-  "Go to next start simple test.  This is to check if sorting is working."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-func main(arg1, arg2) {
-	another_func(arg1)
-}")
-      (tree-sitter-mode)
-      (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "parameter.outer"))
-                      nil nil nil)
-                     20)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-start-unicode ()
-  "Go to next start with unicode in comment."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Łukasz
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      nil nil nil)
-                     11)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-end-simple ()
-  "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-")
-      (tree-sitter-mode)
-      (goto-char 1)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      nil t nil)
-                     43)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-end-multi ()
-  "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-")
-      (tree-sitter-mode)
-      (goto-char 46)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      nil t nil)
-                     81)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi ()
-  "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-
-int main3() {
-    printf(\"hello3\")
-}
-")
-      (tree-sitter-mode)
-      (goto-char 83)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      t t nil)
-                     81)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end ()
-  "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-
-int main3() {
-    printf(\"hello3\")
-}
-")
-      (tree-sitter-mode)
-      (goto-char 82)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      t t nil)
-                     43)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end-with-comment-at-end ()
-  "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-} // one
-
-int main2() {
-    printf(\"hello2\")
-} // two
-
-int main3() {
-    printf(\"hello3\")
-} // three
-")
-      (tree-sitter-mode)
-      (goto-char 82)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      t t nil)
-                     43)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-goto-next-end-multi-on-end ()
-  "Testing going to end of previous one while on end of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-
-int main3() {
-    printf(\"hello3\")
-}
-")
-      (tree-sitter-mode)
-      ;; somehow (goto-char 44) (point) gives 43?
-      (goto-char 43)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      nil t nil)
-                     81)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-start-multi-on-start ()
-  "Testing going to start of previous one while on start of current one."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// mango
-int main() {
-    printf(\"hello\")
-}
-
-int main2() {
-    printf(\"hello2\")
-}
-
-int main3() {
-    printf(\"hello3\")
-}
-")
-      (tree-sitter-mode)
-      (goto-char 46)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      t nil nil)
-                     10)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested ()
-  "Go to next start simple test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".go"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (setq major-mode 'go-mode)
-      (insert "// comment
+    (go-nested . "// comment
 func main() {
 	fmt.Println(\"howdy bruh!\")
 	func() {
 		fmt.Println(\"yo!\")
 	}
 }")
-      (tree-sitter-mode)
-      (goto-char 66)
-      (should (equal (evil-textobj-tree-sitter--get-goto-location
-                      (mapcar #'intern (list "function.outer"))
-                      t nil nil)
-                     55)))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested-2 ()
-  "Go to previous nested function test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
-         (filename (concat "/tmp/" bufname)))
-    (setq python-indent-guess-indent-offset nil
-          python-indent-offset 4)
-    (find-file filename)
-    (with-current-buffer bufname
-      (setq major-mode 'python-mode)
-      (insert "def func ():
-    var1
-    def nested():
-        var2
-    var3
-")
-      (tree-sitter-mode)
-      ;; place the cursor after the nested function (on var3)
-      (goto-char 58)
-      (let ((pos (evil-textobj-tree-sitter--get-goto-location
-                  (mapcar #'intern (list "function.outer")) t nil nil)))
-        ;; cursor should be on the beginning of nested function after move to the previous outer function
-        (should (equal pos 27))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
-
-(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested-3 ()
-  "Go to previous nested complex test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
-         (filename (concat "/tmp/" bufname)))
-    (setq python-indent-guess-indent-offset nil
-          python-indent-offset 4)
-    (find-file filename)
-    (with-current-buffer bufname
-      (setq major-mode 'python-mode)
-      (insert "def func ():
+    (py-complex . "def func ():
     var1
     def func2(): pass
     def nested():
@@ -508,76 +72,168 @@ func main() {
             var3
         var4
     var5
-")
-      (tree-sitter-mode)
-      ;; place the cursor on var2 (inside two nested functions)
-      (goto-char 71)
-      (let ((pos (evil-textobj-tree-sitter--get-goto-location
-                  (mapcar #'intern (list "function.outer")) t nil nil)))
-        ;; cursor should be on the beginning of nested
-        (should (equal pos 49))))
-    (set-buffer-modified-p nil)
+")))
+
+(ert-deftest evil-textobj-tree-sitter-within-unicode-test ()
+  "Check inner range queries within unicode buffers."
+  ;; function.inner selects brackets in treesit queries but not in tree-sitter ones
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 31 "function.inner" (cons 28 43) 'c-unicode)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 31 "function.inner" (cons 22 45) 'c-unicode))
+
+(ert-deftest evil-textobj-tree-sitter-within-unicode-test-outer ()
+  "Check outer range queries within unicode buffers."
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 31 "function.outer" (cons 11 45) 'c-unicode)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 31 "function.outer" (cons 11 45) 'c-unicode))
+
+(ert-deftest evil-textobj-tree-sitter-within-multibyte-buffers ()
+  "Check range in multibyte comment before."
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 35 "parameter.inner" (cons 35 44) 'c-multibyte)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 35 "parameter.inner" (cons 35 44) 'c-multibyte))
+
+(ert-deftest evil-textobj-tree-sitter-within-unicode-test3 ()
+  "Check range with multibyte code."
+  (evil-textobj-tree-sitter--range-test 'go-mode nil 31 "parameter.inner" (cons 26 41) 'go-multibyte-code)
+  (evil-textobj-tree-sitter--range-test 'go-ts-mode t 31 "parameter.inner" (cons 26 41) 'go-multibyte-code))
+
+(ert-deftest evil-textobj-tree-sitter-within-test ()
+  "Check range when we are within the textobj with buffer having only ASCII chars."
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 31 "function.outer" (cons 11 45) 'c-simple)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 31 "function.outer" (cons 11 45) 'c-simple))
+
+(ert-deftest evil-textobj-tree-sitter-lookahed-test ()
+  "Check range when we are before the textobj with buffer having only ASCII chars."
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 1 "function.outer" (cons 11 45) 'c-simple)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 1 "function.outer" (cons 11 45) 'c-simple))
+
+(ert-deftest evil-textobj-tree-sitter-right-at-start-test ()
+  "Checking for off by one errors at start."
+  (evil-textobj-tree-sitter--range-test 'c-mode nil 11 "function.outer" (cons 11 45) 'c-simple)
+  (evil-textobj-tree-sitter--range-test 'c-ts-mode t 11 "function.outer" (cons 11 45) 'c-simple))
+
+
+;;; Reading query files
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-simple ()
+  "Simple query read check."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p ";; \"Classes\"" (evil-textobj-tree-sitter--get-query "zig" t)))))
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-nocomment ()
+  "Check a query file with no comment."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p "(function_definition" (evil-textobj-tree-sitter--get-query "bash" t)))))
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-nested ()
+  "Check a query with nested files to be loaded."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p "; inherits: (jsx)" (evil-textobj-tree-sitter--get-query "typescript" t)))))
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-nested-nofile ()
+  "Check a file pointing to a non existent file."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p "; inherits: (jsx)" (evil-textobj-tree-sitter--get-query "javascript" t)))))
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-nested-multi ()
+  "Check a query with multiple nesting items."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p "; inherits: (javascript)" (evil-textobj-tree-sitter--get-query "tsx" t)))))
+
+(ert-deftest evil-textoj-tree-sitter-check-query-read-non-top-level ()
+  "Check a non top level direct query."
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
+    (should (string-prefix-p "; inherits: (javascript)" (evil-textobj-tree-sitter--get-query "typescript" nil)))))
+
+(defun evil-textobj-tree-sitter--goto-test (mode treesit start textobj pos prev end content)
+  "Check for location of goto actions.
+
+`MODE' is the `major-mode' to be used.
+`TREESIT' non nil will use `treesit'.
+`CONTENT' is the content to be used.
+`START' is the starting position.
+`TEXTOBJ' is the textobject to check.
+`PREV' goes to previous textobj.
+`END' goes to end of textobj.
+`POS' is the position that should be returned."
+  (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
+         (buffer (get-buffer-create bufname)))
+    (with-current-buffer buffer
+      (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
+      (funcall mode)
+      (if (not treesit) (tree-sitter-mode))
+      (goto-char start)
+      (should (equal (evil-textobj-tree-sitter--get-goto-location
+                      (list (intern textobj)) prev end nil)
+                     pos)))
     (kill-buffer bufname)))
 
-(ert-deftest evil-textobj-tree-sitter-goto-next-end-nested-2 ()
-  "Go to next nested function test."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".py"))
-         (filename (concat "/tmp/" bufname)))
-    (setq python-indent-guess-indent-offset nil
-          python-indent-offset 4)
-    (find-file filename)
-    (with-current-buffer bufname
-      (setq major-mode 'python-mode)
+(ert-deftest evil-textobj-tree-sitter-goto-next-start-simple ()
+  "Go to next start in ASCII buffers."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 1 "function.outer" 11 nil nil 'c-simple)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 1 "function.outer" 11 nil nil 'c-simple))
 
-      (insert "def func ():
-    var1
-    def nested():
-        var2
-    var3
-")
-      (tree-sitter-mode)
-      ;; place the cursor before the nested function (on var1)
-      (goto-char 18)
-      (let ((pos (evil-textobj-tree-sitter--get-goto-location
-                  (mapcar #'intern (list "function.outer")) nil t nil)))
-        ;; cursor should be on the end of nested function (var2)
-        (should (equal pos 52))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
+(ert-deftest evil-textobj-tree-sitter-goto-next-start-multiple-textobjects ()
+  "Check to see if we are able to find first one when we have multiple textobjects."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 1 "parameter.outer" 25 nil nil 'c-multibyte)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 1 "parameter.outer" 25 nil nil 'c-multibyte))
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-end-simple ()
+  "Check if we can navigate to end of a textobj."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 1 "function.outer" 69 nil t 'c-multibyte)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 1 "function.outer" 69 nil t 'c-multibyte))
+
+(ert-deftest evil-textobj-tree-sitter-goto-next-end-multi ()
+  "Goto end when we have multiple functions."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 1 "function.outer" 43 nil t 'c-multiple-funcs)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 1 "function.outer" 43 nil t 'c-multiple-funcs))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi ()
+  "Goto end of previous textobj."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 69 "function.outer" 43 t t 'c-multiple-funcs)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 69 "function.outer" 43 t t 'c-multiple-funcs))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-end-multi-on-end ()
+  "Testing going to end of previous one while on end of current one."
+  (evil-textobj-tree-sitter--goto-test 'c-mode nil 82 "function.outer" 43 t t 'c-multiple-funcs)
+  (evil-textobj-tree-sitter--goto-test 'c-ts-mode t 82 "function.outer" 43 t t 'c-multiple-funcs))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested ()
+  "Goto the start of the previous textobj in a nested scenario."
+  (evil-textobj-tree-sitter--goto-test 'go-mode nil 66 "function.outer" 55 t nil 'go-nested)
+  (evil-textobj-tree-sitter--goto-test 'go-ts-mode t 66 "function.outer" 55 t nil 'go-nested))
+
+(ert-deftest evil-textobj-tree-sitter-goto-previous-start-nested-3 ()
+  "Go to previous nested complex test."
+  (evil-textobj-tree-sitter--goto-test 'python-mode nil 71 "function.outer" 49 t nil 'py-complex)
+  (evil-textobj-tree-sitter--goto-test 'python-ts-mode t 71 "function.outer" 49 t nil 'py-complex))
 
 ;;; `thing-at-point' tests
-(ert-deftest evil-textobj-tree-sitter-thing-at-point ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Łukasz
-int main() {
-    printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal (thing-at-point 'function t) "int main() {
-    printf(\"hello\")
-}")))
-    (set-buffer-modified-p nil)
+
+(defun evil-textobj-tree-sitter--thing-at-point-test (mode treesit start thing content selection range)
+  "Check ranges of tree-sitter targets.
+
+`MODE' is the `major-mode' to be used.
+`TREESIT' non nil will use `treesit'.
+`CONTENT' is the content to be used.
+`START' is the starting position.
+`THING' is the thing to select.
+`SELECTION' is the selection that `thing-at-point' will return."
+  (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
+         (buffer (get-buffer-create bufname)))
+    (with-current-buffer buffer
+      (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
+      (funcall mode)
+      (if (not treesit) (tree-sitter-mode))
+      (goto-char start)
+      (should (equal (thing-at-point thing t) selection))
+      (should (equal (bounds-of-thing-at-point thing) range)))
     (kill-buffer bufname)))
 
-(ert-deftest evil-textobj-tree-sitter-thing-at-point-bounds ()
-  "Simple check with point inside the calling thigy and no unicode chars."
-  (let* ((bufname (concat (make-temp-name "evil-textobj-tree-sitter-test--") ".c"))
-         (filename (concat "/tmp/" bufname)))
-    (find-file filename)
-    (with-current-buffer bufname
-      (insert "// Łukasz
-int main() {
+(ert-deftest evil-textobj-tree-sitter-thing-at-point ()
+  "Check if `thing-at-point' returns correct result."
+  (let ((selection "int main() {
     printf(\"hello\")
-}")
-      (tree-sitter-mode)
-      (goto-char 31)
-      (should (equal (bounds-of-thing-at-point 'function) (cons 11 45))))
-    (set-buffer-modified-p nil)
-    (kill-buffer bufname)))
+}"))
+    (evil-textobj-tree-sitter--thing-at-point-test 'c-mode nil 31 'function 'c-unicode selection (cons 11 45))
+    (evil-textobj-tree-sitter--thing-at-point-test 'c-ts-mode t 31 'function 'c-unicode selection (cons 11 45))))
 
 ;;; evil-textobj-tree-sitter-test.el ends here

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -157,42 +157,42 @@ int main() {
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-simple ()
   "Simple query read check."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p ";; \"Classes\""
                              (evil-textobj-tree-sitter--get-query "zig"
                                                                   t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nocomment ()
   "Check a query file with no comment."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "(function_definition"
                              (evil-textobj-tree-sitter--get-query "bash"
                                                                   t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested ()
   "Check a query with nested files to be loaded."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (jsx)"
                              (evil-textobj-tree-sitter--get-query "typescript"
                                                                   t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested-nofile ()
   "Check a file pointing to a non existent file."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (jsx)"
                              (evil-textobj-tree-sitter--get-query "javascript"
                                                                   t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-nested-multi ()
   "Check a query with multiple nesting items."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (javascript)"
                              (evil-textobj-tree-sitter--get-query "tsx"
                                                                   t)))))
 
 (ert-deftest evil-textoj-tree-sitter-check-query-read-non-top-level ()
   "Check a non top level direct query."
-  (let ((evil-textobj-tree-sitter--queries-dir "fixtures/"))
+  (let ((evil-textobj-tree-sitter--get-queries-dir-func (lambda () "fixtures/")))
     (should (string-prefix-p "; inherits: (javascript)"
                              (evil-textobj-tree-sitter--get-query "typescript"
                                                                   nil)))))

--- a/evil-textobj-tree-sitter-test.el
+++ b/evil-textobj-tree-sitter-test.el
@@ -23,28 +23,6 @@
 (treesit-install-language-grammar 'go)
 (treesit-install-language-grammar 'gomod)
 
-(defun evil-textobj-tree-sitter--range-test (mode treesit start textobj range content)
-  "Check ranges of tree-sitter targets.
-
-`MODE' is the `major-mode' to be used.
-`TREESIT' non nil will use `treesit'.
-`CONTENT' is the content to be used.
-`START' is the starting position.
-`TEXTOBJ' is the textobject to check.
-`RANGE' is the range that should be returned."
-  (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
-         (buffer (get-buffer-create bufname)))
-    (with-current-buffer buffer
-      (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
-      (funcall mode)
-      (if (not treesit) (tree-sitter-mode))
-      (message "%s" major-mode)
-      (goto-char start)
-      (should (equal
-               (evil-textobj-tree-sitter--range 1 (list (intern textobj)))
-               range)))
-    (kill-buffer buffer)))
-
 (defvar evil-textobj-tree-sitter--test-file-content
   '((c-simple . "// Lukasz
 int main() {
@@ -88,6 +66,29 @@ func main() {
         var4
     var5
 ")))
+
+
+(defun evil-textobj-tree-sitter--range-test (mode treesit start textobj range content)
+  "Check ranges of tree-sitter targets.
+
+`MODE' is the `major-mode' to be used.
+`TREESIT' non nil will use `treesit'.
+`CONTENT' is the content to be used.
+`START' is the starting position.
+`TEXTOBJ' is the textobject to check.
+`RANGE' is the range that should be returned."
+  (let* ((bufname (make-temp-name "evil-textobj-tree-sitter-test--"))
+         (buffer (get-buffer-create bufname)))
+    (with-current-buffer buffer
+      (insert (alist-get content evil-textobj-tree-sitter--test-file-content))
+      (funcall mode)
+      (if (not treesit) (tree-sitter-mode))
+      (message "%s" major-mode)
+      (goto-char start)
+      (should (equal
+               (evil-textobj-tree-sitter--range 1 (list (intern textobj)))
+               range)))
+    (kill-buffer buffer)))
 
 (ert-deftest evil-textobj-tree-sitter-within-unicode-test ()
   "Check inner range queries within unicode buffers."

--- a/evil-textobj-tree-sitter-thing-at-point.el
+++ b/evil-textobj-tree-sitter-thing-at-point.el
@@ -20,7 +20,7 @@
   "Return the bounds of the `GROUP' at point."
   (when-let* ((entity (evil-textobj-tree-sitter--get-within (list (intern group)) 1 nil))
               (pos (cdr (car entity))))
-    (cons (byte-to-position (car pos)) (byte-to-position (cadr pos)))))
+    (cons (car pos) (cadr pos))))
 
 (put 'function 'bounds-of-thing-at-point (lambda () (evil-textobj-tree-sitter--thing-at-point-bounds "function.outer")))
 (put 'loop 'bounds-of-thing-at-point (lambda () (evil-textobj-tree-sitter--thing-at-point-bounds "loop.outer")))

--- a/evil-textobj-tree-sitter-thing-at-point.el
+++ b/evil-textobj-tree-sitter-thing-at-point.el
@@ -3,7 +3,7 @@
 ;; URL: https://github.com/meain/evil-textobj-tree-sitter
 ;; Keywords: evil, tree-sitter, text-object, convenience
 ;; SPDX-License-Identifier: Apache-2.0
-;; Package-Requires: ((emacs "25.1") (tree-sitter "0.15.0"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 0.1
 
 ;;; Commentary:

--- a/evil-textobj-tree-sitter.el
+++ b/evil-textobj-tree-sitter.el
@@ -3,7 +3,7 @@
 ;; URL: https://github.com/meain/evil-textobj-tree-sitter
 ;; Keywords: evil, tree-sitter, text-object, convenience
 ;; SPDX-License-Identifier: Apache-2.0
-;; Package-Requires: ((emacs "25.1") (tree-sitter "0.15.0"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Version: 0.1
 
 ;;; Commentary:
@@ -25,6 +25,9 @@
 
 ;; This package also provides with thing-at-point functions for common
 ;; textobjects like functions, loops, conditionals etc.
+
+;; You need to either have elisp-tree-sitter installed or have Emacs
+;; version >=29 for this package to work.
 
 ;;; Code:
 

--- a/scripts/get-helix-queries
+++ b/scripts/get-helix-queries
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+HELIX_DIR="${1:-../helix}"
+
+find $HELIX_DIR/runtime/queries -name 'textobjects.scm' |
+    cut -d'/' -f5- |
+    while read -r file; do
+        dir="$(dirname "$file")"
+        filename="$(basename "$file")"
+
+        mkdir -p "treesit-queries/$dir"
+        # match? to match mapping is kinda hacky
+        sed 's|\(@[^\.]*\)\.inside|\1.inner|g;s|\(@[^\.]*\)\.around|\1.outer|g;s|#match? @\([^ ]*\) "\([^"]*\)"|#match "\2" @\1|g' \
+            "$HELIX_DIR/runtime/queries/$file" > "treesit-queries/$dir/$filename"
+    done

--- a/scripts/get-helix-queries
+++ b/scripts/get-helix-queries
@@ -12,6 +12,6 @@ find $HELIX_DIR/runtime/queries -name 'textobjects.scm' |
 
         mkdir -p "treesit-queries/$dir"
         # match? to match mapping is kinda hacky
-        sed 's|\(@[^\.]*\)\.inside|\1.inner|g;s|\(@[^\.]*\)\.around|\1.outer|g;s|#match? @\([^ ]*\) "\([^"]*\)"|#match "\2" @\1|g' \
+        sed 's|\(@[^\.]*\)\.inside|\1.inner|g;s|\(@[^\.]*\)\.around|\1.outer|g;s|#match? @\([^ ]*\) "\([^"]*\)"|#match "\2" @\1|g;s/#eq?/#equal/g' \
             "$HELIX_DIR/runtime/queries/$file" > "treesit-queries/$dir/$filename"
     done

--- a/treesit-queries/awk/textobjects.scm
+++ b/treesit-queries/awk/textobjects.scm
@@ -1,0 +1,10 @@
+
+(func_def name: (identifier) (block) @function.inner) @function.outer
+
+(param_list (_) @parameter.inner) @parameter.outer
+
+(args (_) @parameter.inner) @parameter.outer
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/c-sharp/textobjects.scm
+++ b/treesit-queries/c-sharp/textobjects.scm
@@ -1,0 +1,21 @@
+[
+  (class_declaration body: (_) @class.inner)
+  (struct_declaration body: (_) @class.inner)
+  (interface_declaration body: (_) @class.inner)
+  (enum_declaration body: (_) @class.inner)
+  (delegate_declaration)
+  (record_declaration body: (_) @class.inner)
+  (record_struct_declaration body: (_) @class.inner)
+] @class.outer
+
+(constructor_declaration body: (_) @function.inner) @function.outer
+
+(destructor_declaration body: (_) @function.inner) @function.outer
+
+(method_declaration body: (_) @function.inner) @function.outer
+
+(property_declaration (_) @function.inner) @function.outer
+
+(parameter (_) @parameter.inner) @parameter.outer
+
+(comment)+ @comment.outer

--- a/treesit-queries/c/textobjects.scm
+++ b/treesit-queries/c/textobjects.scm
@@ -1,0 +1,21 @@
+(function_definition
+  body: (_) @function.inner) @function.outer
+
+(struct_specifier
+  body: (_) @class.inner) @class.outer
+
+(enum_specifier
+  body: (_) @class.inner) @class.outer
+
+(union_specifier
+  body: (_) @class.inner) @class.outer
+
+(parameter_list 
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(argument_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/cairo/textobjects.scm
+++ b/treesit-queries/cairo/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: rust

--- a/treesit-queries/cmake/textobjects.scm
+++ b/treesit-queries/cmake/textobjects.scm
@@ -1,0 +1,15 @@
+[
+  (macro_def)
+  (function_def)
+] @function.outer
+
+(argument) @parameter.inner
+
+[
+  (bracket_comment)
+  (line_comment)
+] @comment.inner
+
+(line_comment)+ @comment.outer
+
+(bracket_comment) @comment.outer

--- a/treesit-queries/cpp/textobjects.scm
+++ b/treesit-queries/cpp/textobjects.scm
@@ -1,0 +1,7 @@
+; inherits: c
+
+(lambda_expression
+  body: (_) @function.inner) @function.outer
+
+(class_specifier
+  body: (_) @class.inner) @class.outer

--- a/treesit-queries/crystal/textobjects.scm
+++ b/treesit-queries/crystal/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: ruby

--- a/treesit-queries/d/textobjects.scm
+++ b/treesit-queries/d/textobjects.scm
@@ -1,0 +1,9 @@
+(function_declaration (function_body) @function.inner) @function.outer
+(comment) @comment.inner
+(comment)+ @comment.outer
+(class_declaration (aggregate_body) @class.inner) @class.outer
+(interface_declaration (aggregate_body) @class.inner) @class.outer
+(struct_declaration (aggregate_body) @class.inner) @class.outer
+(unittest_declaration (block_statement) @test.inner) @test.outer
+(parameter) @parameter.inner
+(template_parameter) @parameter.inner

--- a/treesit-queries/dhall/textobjects.scm
+++ b/treesit-queries/dhall/textobjects.scm
@@ -1,0 +1,23 @@
+(lambda_expression
+  (label) @parameter.inner
+  (expression) @function.inner
+) @function.outer
+
+(forall_expression
+  (label) @parameter.inner
+  (expression) @function.inner
+) @function.outer
+
+(assert_expression
+  (expression) @test.inner
+) @test.outer
+
+[
+  (block_comment_content)
+  (line_comment_content)
+] @comment.inner
+
+[
+  (block_comment)
+  (line_comment)
+] @comment.outer

--- a/treesit-queries/ecma/textobjects.scm
+++ b/treesit-queries/ecma/textobjects.scm
@@ -1,0 +1,36 @@
+(function_declaration
+  body: (_) @function.inner) @function.outer
+
+(function
+  body: (_) @function.inner) @function.outer
+
+(arrow_function
+  body: (_) @function.inner) @function.outer
+
+(method_definition
+  body: (_) @function.inner) @function.outer
+
+(generator_function_declaration
+  body: (_) @function.inner) @function.outer
+
+(class_declaration
+  body: (class_body) @class.inner) @class.outer
+
+(class
+  (class_body) @class.inner) @class.outer
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.outer
+    (class_declaration) @class.outer 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/elixir/textobjects.scm
+++ b/treesit-queries/elixir/textobjects.scm
@@ -1,0 +1,35 @@
+; Function heads and guards have no body at all, so `keywords` and `do_block` nodes are both optional
+((call
+   target: (identifier) @_keyword
+   (arguments
+     [
+       (call
+         (arguments (_)? @parameter.inner))
+       ; function has a guard
+       (binary_operator
+         left:
+           (call
+             (arguments (_)? @parameter.inner)))
+     ]
+     ; body is "do: body" instead of a do-block
+     (keywords
+       (pair
+         value: (_) @function.inner))?)?
+   (do_block (_)* @function.inner)?)
+ (#match "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$" @_keyword)) @function.outer
+
+(anonymous_function
+  (stab_clause right: (body) @function.inner)) @function.outer
+
+((call
+   target: (identifier) @_keyword
+   (do_block (_)* @class.inner))
+ (#match "^(defmodule|defprotocol|defimpl)$" @_keyword)) @class.outer
+
+((call
+  target: (identifier) @_keyword
+  (arguments ((string) . (_)?))
+  (do_block (_)* @test.inner)?)
+ (#match "^(test|describe)$" @_keyword)) @test.outer
+
+(comment)+ @comment.outer @comment.inner

--- a/treesit-queries/elm/textobjects.scm
+++ b/treesit-queries/elm/textobjects.scm
@@ -1,0 +1,63 @@
+(line_comment) @comment.inner
+(line_comment)+ @comment.outer
+(block_comment) @comment.inner
+(block_comment)+ @comment.outer
+
+((type_annotation)?
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (_) @function.inner
+  )
+) @function.outer
+
+(parenthesized_expr
+  (anonymous_function_expr
+    (
+      (arrow)
+      (_) @function.inner
+    )
+  )
+) @function.outer
+
+(value_declaration
+  (function_declaration_left
+    (lower_pattern
+      (lower_case_identifier) @parameter.inner @parameter.outer
+    )
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (pattern) @parameter.inner @parameter.outer
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (tuple_pattern
+      (pattern) @parameter.inner
+    ) @parameter.outer
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (record_pattern
+      (lower_pattern
+        (lower_case_identifier) @parameter.inner
+      )
+    ) @parameter.outer
+  )
+)
+
+(parenthesized_expr
+  (anonymous_function_expr
+    (
+      (backslash)
+      (pattern) @parameter.inner
+      (arrow)
+    )
+  )
+)

--- a/treesit-queries/erlang/textobjects.scm
+++ b/treesit-queries/erlang/textobjects.scm
@@ -1,0 +1,16 @@
+(function_clause
+  pattern: (arguments (_)? @parameter.inner)
+  body: (_) @function.inner) @function.outer
+
+(anonymous_function
+  (stab_clause body: (_) @function.inner)) @function.outer
+
+(comment (comment_content) @comment.inner) @comment.outer
+
+; EUnit test names.
+; (CommonTest cases are not recognizable by syntax alone.)
+((function_clause
+   name: (atom) @_name
+   pattern: (arguments (_)? @parameter.inner)
+   body: (_) @test.inner) @test.outer
+ (#match "_test$" @_name))

--- a/treesit-queries/fish/textobjects.scm
+++ b/treesit-queries/fish/textobjects.scm
@@ -1,0 +1,5 @@
+(function_definition) @function.outer
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/gdscript/textobjects.scm
+++ b/treesit-queries/gdscript/textobjects.scm
@@ -1,0 +1,17 @@
+
+(class_definition
+  (body) @class.inner) @class.outer
+
+(function_definition
+  (body) @function.inner) @function.outer
+
+(parameters 
+  [
+    (identifier)
+    (typed_parameter)
+    (default_parameter)    
+    (typed_default_parameter)  
+  ] @parameter.inner @parameter.outer)
+
+(comment) @comment.inner
+(comment)+ @comment.outer

--- a/treesit-queries/git-commit/textobjects.scm
+++ b/treesit-queries/git-commit/textobjects.scm
@@ -1,0 +1,2 @@
+(comment) @comment.inner
+(comment)+ @comment.outer

--- a/treesit-queries/gleam/textobjects.scm
+++ b/treesit-queries/gleam/textobjects.scm
@@ -1,0 +1,11 @@
+(function
+  parameters: (function_parameters (function_parameter)? @parameter.inner)
+  body: (function_body) @function.inner) @function.outer
+
+(anonymous_function
+  body: (function_body) @function.inner) @function.outer
+
+((function
+   name: (identifier) @_name
+   body: (function_body) @test.inner) @test.outer
+ (#match "_test$" @_name))

--- a/treesit-queries/glsl/textobjects.scm
+++ b/treesit-queries/glsl/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: c

--- a/treesit-queries/go/textobjects.scm
+++ b/treesit-queries/go/textobjects.scm
@@ -1,0 +1,33 @@
+(function_declaration
+  body: (block)? @function.inner) @function.outer
+
+(func_literal
+  (_)? @function.inner) @function.outer
+
+(method_declaration
+  body: (block)? @function.inner) @function.outer
+
+;; struct and interface declaration as class textobject?
+(type_declaration
+  (type_spec (type_identifier) (struct_type (field_declaration_list (_)?) @class.inner))) @class.outer
+
+(type_declaration
+  (type_spec (type_identifier) (interface_type (method_spec)+ @class.inner))) @class.outer
+
+(type_parameter_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(parameter_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(argument_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer
+
+((function_declaration
+   name: (identifier) @_name
+   body: (block)? @test.inner) @test.outer
+ (#match "^Test" @_name))

--- a/treesit-queries/haskell/textobjects.scm
+++ b/treesit-queries/haskell/textobjects.scm
@@ -1,0 +1,13 @@
+(comment) @comment.inner
+
+[
+  (adt)
+  (type_alias)
+  (newtype)
+] @class.outer
+
+((signature)? (function rhs:(_) @function.inner)) @function.outer 
+(exp_lambda) @function.outer
+
+(adt (type_variable) @parameter.inner)
+(patterns (_) @parameter.inner)

--- a/treesit-queries/heex/textobjects.scm
+++ b/treesit-queries/heex/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.outer @comment.inner

--- a/treesit-queries/java/textobjects.scm
+++ b/treesit-queries/java/textobjects.scm
@@ -1,0 +1,35 @@
+(method_declaration
+  body: (_) @function.inner) @function.outer
+
+(interface_declaration
+  body: (_) @class.inner) @class.outer
+
+(class_declaration
+  body: (_) @class.inner) @class.outer
+
+(record_declaration
+  body: (_) @class.inner) @class.outer
+
+(enum_declaration
+  body: (_) @class.inner) @class.outer
+
+(formal_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(argument_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inner
+
+(line_comment)+ @comment.outer
+
+(block_comment) @comment.outer

--- a/treesit-queries/javascript/textobjects.scm
+++ b/treesit-queries/javascript/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: ecma

--- a/treesit-queries/jsx/textobjects.scm
+++ b/treesit-queries/jsx/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: ecma

--- a/treesit-queries/julia/textobjects.scm
+++ b/treesit-queries/julia/textobjects.scm
@@ -1,0 +1,46 @@
+(function_definition (_)? @function.inner) @function.outer
+
+(short_function_definition (_)? @function.inner) @function.outer
+
+(macro_definition (_)? @function.inner) @function.outer
+
+(struct_definition (_)? @class.inner) @class.outer
+
+(abstract_definition (_)? @class.inner) @class.outer
+
+(primitive_definition (_)? @class.inner) @class.outer
+
+(parameter_list
+  ; Match all children of parameter_list *except* keyword_parameters
+  ([(identifier)
+    (slurp_parameter)
+    (optional_parameter)
+    (typed_parameter)
+    (tuple_expression)
+    (interpolation_expression)
+    (call_expression)]
+  @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(keyword_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(argument_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_parameter_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(line_comment) @comment.inner
+
+(line_comment)+ @comment.outer
+
+(block_comment) @comment.inner
+
+(block_comment)+ @comment.outer
+
+(_expression (macro_identifier
+    (identifier) @_name
+    (#match "^(test|test_throws|test_logs|inferred|test_deprecated|test_warn|test_nowarn|test_broken|test_skip)$" @_name)
+  )
+  .
+  (macro_argument_list) @test.inner) @test.outer

--- a/treesit-queries/just/textobjects.scm
+++ b/treesit-queries/just/textobjects.scm
@@ -1,0 +1,48 @@
+(body) @function.inner
+(recipe) @function.outer
+(expression 
+    if:(expression) @function.inner 
+) 
+(expression 
+    else:(expression) @function.inner
+) 
+(interpolation (expression) @function.inner) @function.outer
+(settinglist (stringlist) @function.inner) @function.outer
+
+(call (NAME) @class.inner) @class.outer
+(dependency (NAME) @class.inner) @class.outer
+(depcall (NAME) @class.inner)
+
+(dependency) @parameter.outer
+(depcall) @parameter.inner
+(depcall (expression) @parameter.inner) 
+
+(stringlist 
+    (string) @parameter.inner
+    . ","? @_end
+    ; Commented out since we don't support `#make-range!` at the moment
+    ; (#make-range! "parameter.around" @parameter.inner @_end)
+)
+(parameters 
+    [(parameter) 
+    (variadic_parameters)] @parameter.inner
+    . " "? @_end
+    ; Commented out since we don't support `#make-range!` at the moment
+    ; (#make-range! "parameter.around" @parameter.inner @_end)
+)
+
+(expression 
+    (condition) @function.inner
+) @function.outer
+(expression 
+    if:(expression) @function.inner 
+)
+(expression 
+    else:(expression) @function.inner
+)
+
+(item [(alias) (assignment) (export) (setting)]) @class.outer
+(recipeheader) @class.outer
+(line) @class.outer
+
+(comment) @comment.outer

--- a/treesit-queries/latex/textobjects.scm
+++ b/treesit-queries/latex/textobjects.scm
@@ -1,0 +1,13 @@
+[
+  (generic_command)
+] @function.outer
+
+[
+  (chapter)
+  (part)
+  (section)
+  (subsection)
+  (subsubsection)
+  (paragraph)
+  (subparagraph)
+] @class.outer

--- a/treesit-queries/llvm-mir/textobjects.scm
+++ b/treesit-queries/llvm-mir/textobjects.scm
@@ -1,0 +1,12 @@
+(basic_block) @function.outer
+
+(argument) @parameter.inner
+
+[
+  (comment)
+  (multiline_comment)
+] @comment.inner
+
+(comment)+ @comment.outer
+
+(multiline_comment) @comment.outer

--- a/treesit-queries/llvm/textobjects.scm
+++ b/treesit-queries/llvm/textobjects.scm
@@ -1,0 +1,20 @@
+(define
+  body: (_) @function.inner) @function.outer
+
+(struct_type
+  (struct_body) @class.inner) @class.outer
+
+(packed_struct_type
+  (struct_body) @class.inner) @class.outer
+
+(array_type
+  (array_vector_body) @class.inner) @class.outer
+
+(vector_type
+  (array_vector_body) @class.inner) @class.outer
+
+(argument) @parameter.inner
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/lua/textobjects.scm
+++ b/treesit-queries/lua/textobjects.scm
@@ -1,0 +1,15 @@
+(function_definition
+  body: (_) @function.inner) @function.outer
+
+(function_declaration
+  body: (_) @function.inner) @function.outer
+
+(parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/nasm/textobjects.scm
+++ b/treesit-queries/nasm/textobjects.scm
@@ -1,0 +1,15 @@
+(preproc_multiline_macro
+  body: (body) @function.inner) @function.outer
+(struc_declaration
+  body: (struc_declaration_body) @class.inner) @class.outer
+(struc_instance
+  body: (struc_instance_body) @class.inner) @class.outer
+
+(preproc_function_def_parameters
+  (word) @parameter.inner)
+(call_syntax_arguments
+  (_) @parameter.inner)
+(operand) @parameter.inner
+
+(comment) @comment.inner
+(comment)+ @comment.outer

--- a/treesit-queries/nim/textobjects.scm
+++ b/treesit-queries/nim/textobjects.scm
@@ -1,0 +1,19 @@
+(routine
+  (block) @function.inner) @function.outer
+
+; @class.inner (types?)
+; @class.outer
+
+; paramListSuffix is strange and i do not understand it
+(paramList
+  (paramColonEquals) @parameter.inner) @parameter.outer
+
+(comment) @comment.inner
+(multilineComment) @comment.inner
+(docComment) @comment.inner
+(multilineDocComment) @comment.inner
+
+(comment)+ @comment.outer
+(multilineComment) @comment.outer
+(docComment)+ @comment.outer
+(multilineDocComment) @comment.outer

--- a/treesit-queries/opencl/textobjects.scm
+++ b/treesit-queries/opencl/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: c

--- a/treesit-queries/pascal/textobjects.scm
+++ b/treesit-queries/pascal/textobjects.scm
@@ -1,0 +1,10 @@
+
+(declType (declClass (declSection) @class.inner)) @class.outer
+
+(defProc body: (_) @function.inner) @function.outer
+
+(declArgs (_) @parameter.inner) @parameter.outer
+(exprArgs (_) @parameter.inner) @parameter.outer
+
+(comment) @comment.inner
+(comment)+ @comment.outer

--- a/treesit-queries/perl/textobjects.scm
+++ b/treesit-queries/perl/textobjects.scm
@@ -1,0 +1,17 @@
+(function_definition 
+  (identifier) (_) @function.inner) @function.outer
+
+(anonymous_function 
+  (_) @function.inner) @function.outer
+
+(argument 
+  (_) @parameter.inner)
+
+[
+  (comments)
+  (pod_statement)
+] @comment.inner
+
+(comments)+ @comment.outer
+
+(pod_statement) @comment.outer

--- a/treesit-queries/php/textobjects.scm
+++ b/treesit-queries/php/textobjects.scm
@@ -1,0 +1,40 @@
+(class_declaration
+  body: (_) @class.inner) @class.outer
+
+(interface_declaration
+  body: (_) @class.inner) @class.outer
+
+(trait_declaration
+  body: (_) @class.inner) @class.outer
+
+(enum_declaration
+  body: (_) @class.inner) @class.outer
+
+(function_definition
+  body: (_) @function.inner) @function.outer
+
+(method_declaration
+  body: (_) @function.inner) @function.outer
+
+(arrow_function 
+  body: (_) @function.inner) @function.outer
+  
+(anonymous_function_creation_expression
+  body: (_) @function.inner) @function.outer
+
+(anonymous_function_use_clause
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(formal_parameters
+  ([
+    (simple_parameter)
+    (variadic_parameter)
+    (property_promotion_parameter)
+  ] @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer

--- a/treesit-queries/po/textobjects.scm
+++ b/treesit-queries/po/textobjects.scm
@@ -1,0 +1,6 @@
+(msgid) @parameter.inner
+
+(comment) @comment.inner
+(comment)+ @comment.outer
+
+

--- a/treesit-queries/ponylang/textobjects.scm
+++ b/treesit-queries/ponylang/textobjects.scm
@@ -1,0 +1,64 @@
+;; Queries for helix to select textobjects: https://docs.helix-editor.com/usage.html#textobjects
+;;  function.inside
+;; function.around
+;; class.inside
+;; class.around
+;; test.inside
+;; test.around
+;; parameter.inside
+;; comment.inside
+;; comment.around
+
+;; Queries for navigating using textobjects
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inner
+
+(line_comment)+ @comment.outer
+(block_comment) @comment.outer
+
+(entity members: (members)? @class.inner) @class.outer
+(object members: (members)? @class.inner) @class.outer
+
+(method
+  body: (block)? @function.inner
+) @function.outer
+(behavior
+  body: (block)? @function.inner
+) @function.outer
+(constructor
+  body: (block)? @function.inner
+) @function.outer
+(lambda
+  body: (block)? @function.inner
+) @function.outside
+
+(params
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer
+)
+(lambda
+  params: ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer
+)
+(typeargs
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer
+)
+(typeparams
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer
+)
+(arguments
+  positional: (positional_args
+                ((_) @parameter.inner . ","? @parameter.outer)? @parameter.outer)
+  ; TODO: get named args right
+  named: (named_args ((_) @parameter.inner . ","? @parameter.outer)? @parameter.outer)
+)
+
+(
+  (entity
+    provides: (type (nominal_type name: (identifier) @_provides))
+    members: (members) @test.inner
+  ) @test.outside
+  (#eq? @_provides "UnitTest")
+)
+

--- a/treesit-queries/ponylang/textobjects.scm
+++ b/treesit-queries/ponylang/textobjects.scm
@@ -59,6 +59,6 @@
     provides: (type (nominal_type name: (identifier) @_provides))
     members: (members) @test.inner
   ) @test.outside
-  (#eq? @_provides "UnitTest")
+  (#equal @_provides "UnitTest")
 )
 

--- a/treesit-queries/python/textobjects.scm
+++ b/treesit-queries/python/textobjects.scm
@@ -1,0 +1,23 @@
+(function_definition
+  body: (block)? @function.inner) @function.outer
+
+(class_definition
+  body: (block)? @class.inner) @class.outer
+
+(parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+  
+(lambda_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(argument_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(comment) @comment.inner
+
+(comment)+ @comment.outer
+
+((function_definition
+   name: (identifier) @_name
+   body: (block)? @test.inner) @test.outer
+ (#match "^test_" @_name))

--- a/treesit-queries/rescript/textobjects.scm
+++ b/treesit-queries/rescript/textobjects.scm
@@ -1,0 +1,112 @@
+; Classes (modules)
+;------------------
+
+(module_declaration definition: ((_) @class.inner)) @class.outer
+
+; Blocks
+;-------
+
+(block (_) @function.inner) @function.outer
+
+; Functions
+;----------
+
+(function body: (_) @function.inner) @function.outer
+
+; Calls
+;------
+
+(call_expression arguments: ((_) @parameter.inner)) @parameter.outer
+
+; Comments
+;---------
+
+(comment) @comment.inner
+(comment)+ @comment.outer
+
+; Parameters
+;-----------
+
+(function parameter: (_) @parameter.inner @parameter.outer)
+
+(formal_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(formal_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(arguments
+  "," @_arguments_start
+  . (_) @parameter.inner
+  @parameter.outer)
+(arguments
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(function_type_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(function_type_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(functor_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(functor_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(type_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(type_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(type_arguments
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(type_arguments
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(decorator_arguments
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(decorator_arguments
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(variant_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(variant_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+
+(polyvar_parameters
+  ","
+  . (_) @parameter.inner
+  @parameter.outer)
+(polyvar_parameters
+  . (_) @parameter.inner
+  . ","?
+  @parameter.outer)
+

--- a/treesit-queries/ruby/textobjects.scm
+++ b/treesit-queries/ruby/textobjects.scm
@@ -1,0 +1,44 @@
+; Class and Modules
+(class
+  body: (_)? @class.inner) @class.outer
+
+(singleton_class
+  value: (_)
+  (_)+ @class.inner) @class.outer
+
+(call
+  receiver: (constant) @class_const
+  method: (identifier) @class_method
+  (#match "Class" @class_const)
+  (#match "new" @class_method)
+  (do_block (_)+ @class.inner)) @class.outer
+  
+(module
+  body: (_)? @class.inner) @class.outer
+
+; Functions and Blocks
+(singleton_method
+  body: (_)? @function.inner) @function.outer
+
+(method
+  body: (_)? @function.inner) @function.outer
+
+(do_block
+  body: (_)? @function.inner) @function.outer
+
+(block
+  body: (_)? @function.inner) @function.outer
+
+; Parameters      
+(method_parameters
+  (_) @parameter.inner) @parameter.outer
+        
+(block_parameters 
+  (_) @parameter.inner) @parameter.outer
+        
+(lambda_parameters 
+  (_) @parameter.inner) @parameter.outer
+
+; Comments
+(comment) @comment.inner 
+(comment)+ @comment.outer

--- a/treesit-queries/rust/textobjects.scm
+++ b/treesit-queries/rust/textobjects.scm
@@ -52,4 +52,4 @@
  ; the test function
  (function_item
    body: (_) @test.inner) @test.outer
- (#eq? @_test_attribute "test"))
+ (#equal @_test_attribute "test"))

--- a/treesit-queries/rust/textobjects.scm
+++ b/treesit-queries/rust/textobjects.scm
@@ -1,0 +1,55 @@
+(function_item
+  body: (_) @function.inner) @function.outer(closure_expression body: (_) @function.inner) @function.outer
+
+(struct_item
+  body: (_) @class.inner) @class.outer
+
+(enum_item
+  body: (_) @class.inner) @class.outer
+
+(union_item
+  body: (_) @class.inner) @class.outer
+
+(trait_item
+  body: (_) @class.inner) @class.outer
+
+(impl_item
+  body: (_) @class.inner) @class.outer
+
+(parameters 
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(closure_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inner
+
+(line_comment)+ @comment.outer
+
+(block_comment) @comment.outer
+
+(; #[test]
+ (attribute_item
+   (attribute
+     (identifier) @_test_attribute))
+ ; allow other attributes like #[should_panic] and comments
+ [
+   (attribute_item)
+   (line_comment)
+ ]*
+ ; the test function
+ (function_item
+   body: (_) @test.inner) @test.outer
+ (#eq? @_test_attribute "test"))

--- a/treesit-queries/sage/textobjects.scm
+++ b/treesit-queries/sage/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/treesit-queries/starlark/textobjects.scm
+++ b/treesit-queries/starlark/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/treesit-queries/sway/textobjects.scm
+++ b/treesit-queries/sway/textobjects.scm
@@ -49,4 +49,4 @@
  ; the test function
  (function_item
    body: (_) @test.inner) @test.outer
- (#eq? @_test_attribute "test"))
+ (#equal @_test_attribute "test"))

--- a/treesit-queries/sway/textobjects.scm
+++ b/treesit-queries/sway/textobjects.scm
@@ -1,0 +1,52 @@
+(function_item
+  body: (_) @function.inner) @function.outer(closure_expression body: (_) @function.inner) @function.outer
+
+(struct_item
+  body: (_) @class.inner) @class.outer
+
+(enum_item
+  body: (_) @class.inner) @class.outer
+
+(trait_item
+  body: (_) @class.inner) @class.outer
+
+(impl_item
+  body: (_) @class.inner) @class.outer
+
+(parameters 
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(type_arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(closure_parameters
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(arguments
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inner
+
+(line_comment)+ @comment.outer
+
+(block_comment) @comment.outer
+
+(; #[test]
+ (attribute_item
+   (attribute
+     (identifier) @_test_attribute))
+ ; allow other attributes like #[should_panic] and comments
+ [
+   (attribute_item)
+   (line_comment)
+ ]*
+ ; the test function
+ (function_item
+   body: (_) @test.inner) @test.outer
+ (#eq? @_test_attribute "test"))

--- a/treesit-queries/tablegen/textobjects.scm
+++ b/treesit-queries/tablegen/textobjects.scm
@@ -1,0 +1,16 @@
+(class
+  body: (_) @class.inner) @class.outer
+
+(multiclass
+  body: (_) @class.inner) @class.outer
+
+(_ argument: _ @parameter.inner)
+
+[
+  (comment)
+  (multiline_comment)
+] @comment.inner
+
+(comment)+ @comment.outer
+
+(multiline_comment) @comment.outer

--- a/treesit-queries/tsx/textobjects.scm
+++ b/treesit-queries/tsx/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: typescript,jsx

--- a/treesit-queries/typescript/textobjects.scm
+++ b/treesit-queries/typescript/textobjects.scm
@@ -1,0 +1,8 @@
+; inherits: ecma
+
+[
+  (interface_declaration 
+    body:(_) @class.inner)
+  (type_alias_declaration 
+    value: (_) @class.inner)
+] @class.outer

--- a/treesit-queries/v/textobjects.scm
+++ b/treesit-queries/v/textobjects.scm
@@ -1,0 +1,27 @@
+(function_declaration
+  body: (block)? @function.inner) @function.outer
+
+((function_declaration
+   name: (identifier) @_name
+   body: (block)? @test.inner) @test.outer
+ (#match "^test" @_name))
+
+(fn_literal
+  body: (block)? @function.inner) @function.outer
+
+(parameter_list
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+(call_expression
+  (argument_list
+    ((_) @parameter.inner) @parameter.outer))
+
+(struct_declaration
+  (struct_field_declaration_list) @class.inner) @class.outer
+
+(struct_field_declaration_list
+  ((_) @parameter.inner) @parameter.outer)
+
+(comment) @comment.inner
+(comment)+ @comment.outer
+

--- a/treesit-queries/verilog/textobjects.scm
+++ b/treesit-queries/verilog/textobjects.scm
@@ -1,0 +1,6 @@
+
+(function_declaration
+ (function_body_declaration
+  (function_identifier
+     (function_identifier
+        (simple_identifier) @function.inner)))) @function.outer

--- a/treesit-queries/zig/textobjects.scm
+++ b/treesit-queries/zig/textobjects.scm
@@ -1,0 +1,23 @@
+(TopLevelDecl (FnProto)
+  (_) @function.inner) @function.outer
+
+(TestDecl (_) @test.inner) @test.outer
+
+; matches all of: struct, enum, union
+; this unfortunately cannot be split up because
+; of the way struct "container" types are defined
+(TopLevelDecl (VarDecl (ErrorUnionExpr (SuffixExpr (ContainerDecl
+    (_) @class.inner))))) @class.outer
+
+(TopLevelDecl (VarDecl (ErrorUnionExpr (SuffixExpr (ErrorSetDecl
+    (_) @class.inner))))) @class.outer
+
+(ParamDeclList
+  ((_) @parameter.inner . ","? @parameter.outer) @parameter.outer)
+
+[
+  (doc_comment)
+  (line_comment)
+] @comment.inner
+(line_comment)+ @comment.outer
+(doc_comment)+ @comment.outer


### PR DESCRIPTION
This branch, currently experimental, adds `evil-texobj-tree-sitter` with the builtin treesit using texobject [queries from helix](https://github.com/helix-editor/helix/tree/master/runtime/queries). Although neovim has more complete queries, the builtin treesit cannot parse most of them. This still gets you most of the way there, but will only miss a few QOL stuff like not including brackets when selecting inside a function etc. The idea is to keep this open and dogfood it for a while and merge it in eventually.


``` emacs-lisp
(use-package evil-textobj-tree-sitter
  :straight (evil-textobj-tree-sitter
             :host github
             :repo "meain/evil-textobj-tree-sitter"
             :files (:defaults "queries" "treesit-queries")
             :branch "treesit")))
```

You can use this branch with straight like above. For more information refer https://github.com/meain/evil-textobj-tree-sitter/issues/76


TODOs

- [x] Update melpa with `queries-dir` https://github.com/melpa/melpa/pull/8669
- [x] Update readme with mention about treesit and updated installation instructions
- [x] Mention about usage and state of helix grammars
- [x] Ensure we have enough tests for the treesit side
- [x] Add script to auto convert helix queries to make it work for treesit
- [x] Fix CI to load treesit grammars