### PR TITLE
Adds matlab-mode to the list of major modes.

### DIFF
--- a/evil-textobj-tree-sitter-core.el
+++ b/evil-textobj-tree-sitter-core.el
@@ -60,6 +60,7 @@
                           (js2-mode . "javascript")
                           (js3-mode . "javascript")
                           (julia-mode . "julia")
+                          (matlab-mode . "matlab")
                           (php-mode . "php")
                           (prisma-mode . "prisma")
                           (python-mode . "python")


### PR DESCRIPTION
Adds `MATLAB` support now that the parser has been accepted in emacs-tree-sitter/tree-sitter-langs#185 and the text-objects in nvim-treesitter/nvim-treesitter-textobjects#468.