### PR TITLE
Use Emacs 29.1 for testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,9 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          # - 27.2
-          # - 28.1
-          - snapshot # test only on snapshot as that has treesit
+          - 29.1
+          # - snapshot # causing issues with compat
     steps:
     - uses: actions/checkout@v2
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
Using `snapshot` was causing issues with package-lint not being able to find the respective compat lib.